### PR TITLE
Change createdAt to joinedTimestamp

### DIFF
--- a/commands/kicksince.js
+++ b/commands/kicksince.js
@@ -65,7 +65,7 @@ async function run(message, args) {
 
     let members = await message.guild.members.fetch()
 
-    members = await members.filter((m) => m.user.createdTimestamp >= time)
+    members = await members.filter((m) => m.joinedTimestamp >= time)
 
     if (members.size >= 50) {
         const confirm = await message.channel.send(


### PR DESCRIPTION
Fixes an issue where the members filter would only account for users created before the duration specified in the command. Now it correctly filters the members by their joinedTimestamp.