### PR TITLE
feat: timeago and timeuntil commands

### DIFF
--- a/src/commands/timeago.ts
+++ b/src/commands/timeago.ts
@@ -1,0 +1,70 @@
+import dayjs = require("dayjs")
+import { CommandInteraction, Message } from "discord.js"
+import { addCooldown, getResponse, onCooldown } from "../utils/cooldownhandler"
+import { MStoTime } from "../utils/functions/date"
+import { getPrefix } from "../utils/guilds/utils"
+import { Categories, Command, NypsiCommandInteraction } from "../utils/models/Command"
+import { CustomEmbed, ErrorEmbed } from "../utils/models/EmbedBuilders"
+
+const cmd = new Command("timeago", "calculate how long ago a date was", Categories.INFO).setAliases(["ta", "ago"])
+
+async function run(message: Message | (CommandInteraction & NypsiCommandInteraction), args: string[]) {
+    if (await onCooldown(cmd.name, message.member)) {
+        const embed = await getResponse(cmd.name, message.member)
+
+        return message.channel.send({ embeds: [embed] })
+    }
+
+    const send = async (data) => {
+        if (!(message instanceof Message)) {
+            await message.reply(data)
+        } else {
+            return await message.channel.send(data)
+        }
+    }
+
+    if (args.length == 0) {
+        return send({ embeds: [new ErrorEmbed(`${getPrefix(message.guild)}ta <date> (label...)`)] })
+    }
+
+    let target = dayjs(args[0])
+
+    if (isNaN(target.unix())) {
+        const day = args[0].split("/")[0]
+        const month = args[0].split("/")[1]
+        const year = args[0].split("/")[2]
+
+        target = dayjs(`${month}/${day}/${year}`)
+    }
+
+    if (isNaN(target.unix())) {
+        return send({ embeds: [new ErrorEmbed("invalid date")] })
+    }
+
+    if (target.isAfter(dayjs())) {
+        return send({ embeds: [new ErrorEmbed("date must be in the past")] })
+    }
+
+    await addCooldown(cmd.name, message.member, 10)
+
+    args.shift()
+
+    const diff = Date.now() - target.toDate().getTime()
+    const length = MStoTime(diff, true)
+
+    let label: string
+
+    if (args[0]) {
+        label = args.join(" ")
+    }
+
+    if (label) {
+        return send({ embeds: [new CustomEmbed(message.member, false, `${label} was **${length} ago**`)] })
+    } else {
+        return send({ embeds: [new CustomEmbed(message.member, false, `${length} ago`)] })
+    }
+}
+
+cmd.setRun(run)
+
+module.exports = cmd

--- a/src/commands/timeuntil.ts
+++ b/src/commands/timeuntil.ts
@@ -1,0 +1,66 @@
+import dayjs = require("dayjs")
+import { CommandInteraction, Message } from "discord.js"
+import { addCooldown, getResponse, onCooldown } from "../utils/cooldownhandler"
+import { MStoTime } from "../utils/functions/date"
+import { getPrefix } from "../utils/guilds/utils"
+import { Categories, Command, NypsiCommandInteraction } from "../utils/models/Command"
+import { CustomEmbed, ErrorEmbed } from "../utils/models/EmbedBuilders"
+
+const cmd = new Command("timeuntil", "calculate time until a date", Categories.INFO).setAliases(["tu", "until"])
+
+async function run(message: Message | (CommandInteraction & NypsiCommandInteraction), args: string[]) {
+    if (await onCooldown(cmd.name, message.member)) {
+        const embed = await getResponse(cmd.name, message.member)
+
+        return message.channel.send({ embeds: [embed] })
+    }
+
+    const send = async (data) => {
+        if (!(message instanceof Message)) {
+            await message.reply(data)
+        } else {
+            return await message.channel.send(data)
+        }
+    }
+
+    if (args.length == 0) {
+        return send({ embeds: [new ErrorEmbed(`${getPrefix(message.guild)}until <date> (label...)`)] })
+    }
+
+    let target = dayjs(args[0])
+
+    if (isNaN(target.unix())) {
+        const day = args[0].split("/")[0]
+        const month = args[0].split("/")[1]
+        const year = args[0].split("/")[2]
+
+        target = dayjs(`${month}/${day}/${year}`)
+    }
+
+    if (isNaN(target.unix())) {
+        return send({ embeds: [new ErrorEmbed("invalid date")] })
+    }
+
+    await addCooldown(cmd.name, message.member, 10)
+
+    args.shift()
+
+    const diff = target.toDate().getTime() - Date.now()
+    const length = MStoTime(diff, true)
+
+    let label: string
+
+    if (args[0]) {
+        label = args.join(" ")
+    }
+
+    if (label) {
+        return send({ embeds: [new CustomEmbed(message.member, false, `**${length}** until ${label}`)] })
+    } else {
+        return send({ embeds: [new CustomEmbed(message.member, false, `${length}`)] })
+    }
+}
+
+cmd.setRun(run)
+
+module.exports = cmd

--- a/src/commands/timeuntil.ts
+++ b/src/commands/timeuntil.ts
@@ -41,6 +41,10 @@ async function run(message: Message | (CommandInteraction & NypsiCommandInteract
         return send({ embeds: [new ErrorEmbed("invalid date")] })
     }
 
+    if (target.isBefore(dayjs())) {
+        return send({ embeds: [new ErrorEmbed("date must be in the future")] })
+    }
+
     await addCooldown(cmd.name, message.member, 10)
 
     args.shift()

--- a/src/utils/functions/date.ts
+++ b/src/utils/functions/date.ts
@@ -1,6 +1,6 @@
 import dayjs = require("dayjs")
 
-export function formatDate(date: Date | number): string {
+export function formatDate(date: Date | number | dayjs.Dayjs): string {
     return dayjs(date).format("MMM D YYYY").toLowerCase()
 }
 

--- a/src/utils/functions/date.ts
+++ b/src/utils/functions/date.ts
@@ -54,36 +54,36 @@ export function MStoTime(ms: number, long = false) {
     if (days > 0) {
         output = output + days
         if (long) {
-            output + "days "
+            output += " days "
         } else {
-            output + "d "
+            output += "d "
         }
     }
 
     if (hours > 0) {
         output = output + hours
         if (long) {
-            output + "hours "
+            output += " hours "
         } else {
-            output + "h "
+            output += "h "
         }
     }
 
     if (minutes > 0) {
         output = output + minutes
         if (long) {
-            output + "minutes "
+            output += " minutes "
         } else {
-            output + "m "
+            output += "m "
         }
     }
 
     if (sec > 0) {
         output = output + sec
         if (long) {
-            output + "seconds "
+            output += " seconds "
         } else {
-            output + "s "
+            output += "s "
         }
     }
 

--- a/src/utils/functions/date.ts
+++ b/src/utils/functions/date.ts
@@ -40,7 +40,7 @@ export function daysUntil(date: Date | number): number {
     return days
 }
 
-export function MStoTime(ms: number) {
+export function MStoTime(ms: number, long = false) {
     const days = Math.floor(ms / (24 * 60 * 60 * 1000))
     const daysms = ms % (24 * 60 * 60 * 1000)
     const hours = Math.floor(daysms / (60 * 60 * 1000))
@@ -52,19 +52,39 @@ export function MStoTime(ms: number) {
     let output = ""
 
     if (days > 0) {
-        output = output + days + "d "
+        output = output + days
+        if (long) {
+            output + "days "
+        } else {
+            output + "d "
+        }
     }
 
     if (hours > 0) {
-        output = output + hours + "h "
+        output = output + hours
+        if (long) {
+            output + "hours "
+        } else {
+            output + "h "
+        }
     }
 
     if (minutes > 0) {
-        output = output + minutes + "m "
+        output = output + minutes
+        if (long) {
+            output + "minutes "
+        } else {
+            output + "m "
+        }
     }
 
     if (sec > 0) {
-        output = output + sec + "s"
+        output = output + sec
+        if (long) {
+            output + "seconds "
+        } else {
+            output + "s "
+        }
     }
 
     return output


### PR DESCRIPTION
- feat: support dayjs date on formatdate func
- feat: add 'long' arg to mstotime func
- fix: mstotime output
- feat: timeuntil command
- feat: timeago command
- fix: prevent date being in the past
