### PR TITLE
docs: replace removed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ better showcase of features can be found on the bot's website: [`nypsi.xyz`](htt
 ##### ✅ information
 
 -   nypsi is able to calculate join positions and join dates of any user in any server, this can be seen with `$join` or `$user`
--   there is also a `$lookup` command which allows you to lookup information about domain names and IP addresses
+-   there is also a `$server` command which allows you to see information about the current guild
 
 ### 🖼 screenshots
 


### PR DESCRIPTION
readme had a command that is no longer a nypsi feature. this deletes the old command and replaces it with another useful information command.