### PR TITLE
refactor: change patreon -> premium

### DIFF
--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -1,12 +1,12 @@
 import { CommandInteraction, Message } from "discord.js";
-import { getBalance, getMulti, updateBalance, userExists, createUser } from "../utils/economy/utils.js";
-import { getPrefix } from "../utils/guilds/utils";
-import { isPremium, getTier, getLastDaily, setLastDaily } from "../utils/premium/utils";
-import { Command, Categories, NypsiCommandInteraction } from "../utils/models/Command";
-import { CustomEmbed } from "../utils/models/EmbedBuilders";
 import { addCooldown, getResponse, onCooldown } from "../utils/cooldownhandler.js";
+import { createUser, getBalance, getMulti, updateBalance, userExists } from "../utils/economy/utils.js";
+import { getPrefix } from "../utils/guilds/utils";
+import { Categories, Command, NypsiCommandInteraction } from "../utils/models/Command";
+import { CustomEmbed } from "../utils/models/EmbedBuilders";
+import { getLastDaily, getTier, isPremium, setLastDaily } from "../utils/premium/utils";
 
-const cmd = new Command("daily", "get your daily bonus (patreon only)", Categories.MONEY);
+const cmd = new Command("daily", "get your daily bonus (premium only)", Categories.MONEY);
 
 async function run(message: Message | (NypsiCommandInteraction & CommandInteraction)) {
     if (await onCooldown(cmd.name, message.member)) {

--- a/src/commands/weekly.ts
+++ b/src/commands/weekly.ts
@@ -1,12 +1,12 @@
 import { CommandInteraction, Message } from "discord.js";
-import { getBalance, getMulti, updateBalance, userExists, createUser } from "../utils/economy/utils.js";
-import { getPrefix } from "../utils/guilds/utils";
-import { isPremium, getTier, getLastWeekly, setLastWeekly } from "../utils/premium/utils";
-import { Command, Categories, NypsiCommandInteraction } from "../utils/models/Command";
-import { CustomEmbed } from "../utils/models/EmbedBuilders";
 import { addCooldown, getResponse, onCooldown } from "../utils/cooldownhandler.js";
+import { createUser, getBalance, getMulti, updateBalance, userExists } from "../utils/economy/utils.js";
+import { getPrefix } from "../utils/guilds/utils";
+import { Categories, Command, NypsiCommandInteraction } from "../utils/models/Command";
+import { CustomEmbed } from "../utils/models/EmbedBuilders";
+import { getLastWeekly, getTier, isPremium, setLastWeekly } from "../utils/premium/utils";
 
-const cmd = new Command("weekly", "get your weekly bonus (patreon only)", Categories.MONEY);
+const cmd = new Command("weekly", "get your weekly bonus (premium only)", Categories.MONEY);
 
 async function run(message: Message | (NypsiCommandInteraction & CommandInteraction)) {
     if (await onCooldown(cmd.name, message.member)) {


### PR DESCRIPTION
Change from "patreon only" to "premium only" due to there being also being ko-fi etc.