### PR TITLE
docs: fix typo

### DIFF
--- a/economy/seasons.md
+++ b/economy/seasons.md
@@ -8,5 +8,5 @@ completely reset. meaning prestige 0.
 
 ## why?
 
-its a good way to keep economy fresh and under control 🙂. and at the end of every season, the top 5 balancesm globally get
+its a good way to keep economy fresh and under control 🙂. and at the end of every season, the top 5 balances globally get
 rewards, such as nypsi premium & real money


### PR DESCRIPTION
this fixes the typo in the guilds page, to remove the unnecessary and quite gobsmacking error you've made when you were making the docs. i expect better next time, and i want a written apology in my discord dms.