### PR TITLE
fix: $disablecmd reset returns incomplete message

### DIFF
--- a/src/commands/disablecommand.ts
+++ b/src/commands/disablecommand.ts
@@ -115,7 +115,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
 
         await updateDisabledCommands(message.guild, filter);
 
-        const embed = new CustomEmbed(message.member, "✅ disabled commands have been").setHeader("disabled commands");
+        const embed = new CustomEmbed(message.member, "✅ disabled commands have been reset").setHeader("disabled commands");
 
         return message.channel.send({ embeds: [embed] });
     } else {


### PR DESCRIPTION
this fixes nypsi's **$disablecmd reset** command to actually say it's been reset, instead of saying "disabled commands have been" without anything else