### PR TITLE
fix: remove boosters from nsfw category

### DIFF
--- a/src/commands/boosters.ts
+++ b/src/commands/boosters.ts
@@ -4,7 +4,7 @@ import { getBoosters, getItems } from "../utils/economy/utils";
 import { Categories, Command, NypsiCommandInteraction } from "../utils/models/Command";
 import { CustomEmbed } from "../utils/models/EmbedBuilders";
 
-const cmd = new Command("boosters", "view your current active boosters", Categories.NSFW).setAliases(["booster"]);
+const cmd = new Command("boosters", "view your current active boosters", Categories.MONEY).setAliases(["booster"]);
 
 cmd.slashEnabled = true;
 


### PR DESCRIPTION
this removes the **$boosters** command from the nsfw category and puts it in the economy/money category instead