### PR TITLE
docs: add missing step to selfhost setup

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -20,6 +20,7 @@ install nodejs on your WSL. [tutorial](https://www.digitalocean.com/community/tu
 -   run `sudo apt install redis-server` and install the package
 -   fill out the .env file with your own info
 -   run `sudo service redis-server start` to start the local redis server
+-   run `npx prisma migrate dev` to get the postgresql database ready
 -   if all went well, `node .` should start your version of nypsi (:
 
 ### postgresql


### PR DESCRIPTION
this adds the **$ npx prisma migrate dev** step to the selfhost guide, which gets the prisma/postgresql database populated and ready for data to be added to the database