### PR TITLE
change how daily works

### DIFF
--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -32,8 +32,8 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
 
     const lastDaily = await getLastDaily(message.member);
 
-    if (lastDaily.getTime() > dayjs().subtract(1, "day").unix() * 1000) {
-        const diff = lastDaily.getTime() - dayjs().subtract(1, "day").unix() * 1000;
+    if (!dayjs(lastDaily.getTime()).isBefore(dayjs(), "day")) {
+        const diff = dayjs().add(1, "day").startOf("day").unix() * 1000 - dayjs().unix() * 1000;
         return message.channel.send({
             embeds: [new ErrorEmbed(`you can get your next daily bonus in **${MStoTime(diff)}**`)],
         });


### PR DESCRIPTION
Change daily countdown to reset at the beginning of each day instead of having to do it exactly every 24h to stay on track