### PR TITLE
fix: remove server ip from $minecraft

### DIFF
--- a/src/commands/minecraft.ts
+++ b/src/commands/minecraft.ts
@@ -50,7 +50,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
     const prefix = await getPrefix(message.guild);
 
     if (args.length == 0) {
-        return send({ embeds: [new ErrorEmbed(`${prefix}minecraft <name/server IP>`)] });
+        return send({ embeds: [new ErrorEmbed(`${prefix}minecraft <name>`)] });
     }
 
     await addCooldown(cmd.name, message.member, 10);


### PR DESCRIPTION
remove the "/server ip" part of the embed when you don't enter any arguments, since they aren't supported anymore