### PR TITLE
refactor: remove footer of $poll

### DIFF
--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -85,7 +85,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         embed.setHeader(message.member.user.tag);
     }
 
-    embed.setFooter({ text: `sent by: ${message.author.tag}` });
+    embed.setFooter({ text: `nypsi.xyz` });
 
     if (!(message instanceof Message)) return;
 

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -85,7 +85,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         embed.setHeader(message.member.user.tag);
     }
 
-    embed.setFooter({ text: `nypsi.xyz` });
+    embed.setFooter({""});
 
     if (!(message instanceof Message)) return;
 

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -85,8 +85,6 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         embed.setHeader(message.member.user.tag);
     }
 
-    embed.setFooter({""});
-
     if (!(message instanceof Message)) return;
 
     message.channel.send({ embeds: [embed] }).then(async (m) => {


### PR DESCRIPTION
this fixes the duplicate name on **$embed**, and shows the main website for nypsi in the footer (replacing the username of the command author).