### PR TITLE
feat: worker notifications only when full

### DIFF
--- a/data/notifications.json
+++ b/data/notifications.json
@@ -32,7 +32,16 @@
   "worker": {
     "id": "worker",
     "name": "worker notifications",
-    "description": "get a dm when one of your workers has reached full capacity"
+    "description": "get a dm when one of your workers has reached full capacity",
+    "types": [
+      { "name": "disabled", "description": "no worker notifications", "value": "Disabled" },
+      {
+        "name": "only when full",
+        "description": "only receive a notification when all of your workers are full",
+        "value": "OnlyWhenFull"
+      },
+      { "name": "all", "description": "receive a notification when any amount of workers are full", "value": "All" }
+    ]
   },
   "booster": {
     "id": "booster",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model DMSettings {
   auction       Boolean         @default(true)
   vote          Boolean         @default(true)
   vote_reminder Boolean         @default(false)
-  worker        WorkerDmSetting @default(Disabled)
+  worker        WorkerDmSetting @default(OnlyWhenFull)
   booster       Boolean         @default(false)
   payment       Boolean         @default(true)
   other         Boolean         @default(true)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,18 +34,24 @@ model User {
 model DMSettings {
   userId String @id
 
-  rob           Boolean @default(true)
-  lottery       Boolean @default(true)
-  premium       Boolean @default(true)
-  auction       Boolean @default(true)
-  vote          Boolean @default(true)
-  vote_reminder Boolean @default(false)
-  worker        Boolean @default(false)
-  booster       Boolean @default(false)
-  payment       Boolean @default(true)
-  other         Boolean @default(true)
+  rob           Boolean         @default(true)
+  lottery       Boolean         @default(true)
+  premium       Boolean         @default(true)
+  auction       Boolean         @default(true)
+  vote          Boolean         @default(true)
+  vote_reminder Boolean         @default(false)
+  worker        WorkerDmSetting @default(Disabled)
+  booster       Boolean         @default(false)
+  payment       Boolean         @default(true)
+  other         Boolean         @default(true)
 
   user User @relation(fields: [userId], references: [id])
+}
+
+enum WorkerDmSetting {
+  Disabled
+  All
+  OnlyWhenFull
 }
 
 model CommandUse {

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -200,7 +200,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         return pageManager();
       } else if (res.isSelectMenu() && res.customId == "typesetting") {
         const selected = options.find((o) => o.data.default).data.value;
-        const value = notificationsData[settingId].types.find((x) => x.value == res.values[0]);
+        const value = notificationsData[selected].types.find((x) => x.value == res.values[0]);
 
         // @ts-expect-error silly ts
         settings[selected] = value.value;

--- a/src/scheduled/clusterjobs/workers.ts
+++ b/src/scheduled/clusterjobs/workers.ts
@@ -70,7 +70,7 @@ async function doWorkerThing() {
     }
 
     if (full.length == workers.length) {
-      data.payload.content = "all of your workers are full";
+      data.payload.content = null;
       data.payload.embed = new CustomEmbed()
         .setDescription("all of your workers are full")
         .setColor(Constants.TRANSPARENT_EMBED_COLOR);

--- a/src/scheduled/clusterjobs/workers.ts
+++ b/src/scheduled/clusterjobs/workers.ts
@@ -1,13 +1,13 @@
 import prisma from "../../init/database";
 import { CustomEmbed } from "../../models/EmbedBuilders";
 import { NotificationPayload } from "../../types/Notification";
+import Constants from "../../utils/Constants";
 import { getBaseWorkers } from "../../utils/functions/economy/utils";
 import { calcWorkerValues, getWorkers } from "../../utils/functions/economy/workers";
 import { addNotificationToQueue, getDmSettings } from "../../utils/functions/users/notifications";
 import { logger } from "../../utils/logger";
 import ms = require("ms");
 import dayjs = require("dayjs");
-import Constants from "../../utils/Constants";
 
 async function doWorkerThing() {
   const query = await prisma.economyWorker.findMany({
@@ -28,7 +28,7 @@ async function doWorkerThing() {
     if (worker.stored + incrementAmount > maxStorage) {
       incrementAmount = maxStorage - worker.stored;
 
-      if ((await getDmSettings(worker.userId)).worker) {
+      if ((await getDmSettings(worker.userId)).worker != "Disabled") {
         dms.add(worker.userId);
       }
     }
@@ -74,11 +74,11 @@ async function doWorkerThing() {
       data.payload.embed = new CustomEmbed()
         .setDescription("all of your workers are full")
         .setColor(Constants.TRANSPARENT_EMBED_COLOR);
-    } else if (full.length == 1) {
+    } else if (full.length == 1 && (await getDmSettings(userId)).worker == "All") {
       data.payload.embed = new CustomEmbed()
         .setDescription(`your ${getBaseWorkers()[full[0]].item_emoji} ${getBaseWorkers()[full[0]].name} is full`)
         .setColor(Constants.TRANSPARENT_EMBED_COLOR);
-    } else {
+    } else if ((await getDmSettings(userId)).worker == "All") {
       data.payload.content = `${full.length} of your workers are full`;
       data.payload.embed = new CustomEmbed()
         .setDescription(

--- a/src/utils/functions/users/notifications.ts
+++ b/src/utils/functions/users/notifications.ts
@@ -11,6 +11,7 @@ interface NotificationData {
   id: string;
   name: string;
   description: string;
+  types?: { name: string; description: string; value: string }[];
 }
 
 const notificationsData: { [key: string]: NotificationData } = require("../../../../data/notifications.json");


### PR DESCRIPTION
default worker notification behaviour will now only notify user when all workers are full, can be changed to disabled, or to have all notifications