### PR TITLE
feat: guild levels update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nypsi",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nypsi",
-      "version": "5.2.5",
+      "version": "5.2.6",
       "license": "ISC",
       "dependencies": {
         "@discordjs/collection": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypsi",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -384,7 +384,7 @@ model ChatReactionStats {
 model EconomyGuild {
   guildName String   @id
   createdAt DateTime
-  balance   Int      @default(0)
+  balance   BigInt   @default(0)
   xp        Int      @default(0)
   level     Int      @default(1)
   motd      String   @default("welcome to the guild fool (/guild motd)")
@@ -399,7 +399,7 @@ model EconomyGuildMember {
   userId           String   @unique
   guildName        String
   joinedAt         DateTime
-  contributedMoney Int      @default(0)
+  contributedMoney BigInt   @default(0)
   contributedXp    Int      @default(0)
 
   user  User         @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/commands/blackjack.ts
+++ b/src/commands/blackjack.ts
@@ -12,7 +12,6 @@ import {
   MessageEditOptions,
 } from "discord.js";
 import * as shuffle from "shuffle-array";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -464,7 +463,7 @@ async function playGame(message: Message | (NypsiCommandInteraction & CommandInt
       const guild = await getGuildByUser(message.member);
 
       if (guild) {
-        await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+        await addToGuildXP(guild.guildName, earnedXp, message.member);
       }
     }
 

--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -466,7 +466,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
       if (contributedMoney > 100) {
         await updateBalance(
           guildMember.userId,
-          (await getBalance(guildMember.userId)) + Math.floor(contributedMoney * 0.25)
+          (await getBalance(guildMember.userId)) + Math.floor(Number(contributedMoney) * 0.25)
         );
 
         if ((await getDmSettings(guildMember.userId)).other) {
@@ -474,7 +474,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
 
           embed.setDescription(
             `since you contributed money to this guild, you have been repaid $**${Math.floor(
-              contributedMoney * 0.25
+              Number(contributedMoney) * 0.25
             ).toLocaleString()}**`
           );
 
@@ -567,7 +567,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
 
       await reaction.message.edit({ embeds: [embed], components: [] });
 
-      embed.setDescription(`$**${(guild.balance + amount).toLocaleString()}**`);
+      embed.setDescription(`$**${(Number(guild.balance) + amount).toLocaleString()}**`);
 
       return setTimeout(() => {
         reaction.message.edit({ embeds: [embed] });

--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -172,7 +172,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
           `**owner** ${guild.owner.lastKnownTag}`,
         true
       );
-      if (guild.level != 5) {
+      if (guild.level < Constants.MAX_GUILD_LEVEL) {
         embed.addField("bank", `**money** $${guild.balance.toLocaleString()}\n**xp** ${guild.xp.toLocaleString()}`, true);
       }
 
@@ -258,7 +258,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
     if (guild.members.length >= (await getMaxMembersForGuild(guild.guildName))) {
       let msg = "your guild already has the max amount of members";
 
-      if (guild.level != 5) {
+      if (guild.level < Constants.MAX_GUILD_LEVEL) {
         msg += `. use ${prefix}guild upgrade to increase this`;
       }
 
@@ -576,7 +576,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
       return send({ embeds: [new ErrorEmbed("you're not in a guild")] });
     }
 
-    if (guild.level == 5) {
+    if (guild.level >= Constants.MAX_GUILD_LEVEL) {
       return send({ embeds: [new CustomEmbed(message.member, `**${guild.guildName}** is at max level`)] });
     }
 

--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -565,7 +565,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
 
       embed.setDescription(`$**${guild.balance.toLocaleString()}**\n  +$**${amount.toLocaleString()}**`);
 
-      await reaction.message.edit({ embeds: [embed] });
+      await reaction.message.edit({ embeds: [embed], components: [] });
 
       embed.setDescription(`$**${(guild.balance + amount).toLocaleString()}**`);
 

--- a/src/commands/highlow.ts
+++ b/src/commands/highlow.ts
@@ -12,7 +12,6 @@ import {
   MessageEditOptions,
 } from "discord.js";
 import * as shuffle from "shuffle-array";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command.js";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -351,7 +350,7 @@ async function playGame(message: Message | (NypsiCommandInteraction & CommandInt
       const guild = await getGuildByUser(message.member);
 
       if (guild) {
-        await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+        await addToGuildXP(guild.guildName, earnedXp, message.member);
       }
     }
 

--- a/src/commands/minesweeper.ts
+++ b/src/commands/minesweeper.ts
@@ -10,7 +10,6 @@ import {
   MessageActionRowComponentBuilder,
   MessageEditOptions,
 } from "discord.js";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command.js";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -354,7 +353,7 @@ async function playGame(message: Message | (NypsiCommandInteraction & CommandInt
       const guild = await getGuildByUser(message.member);
 
       if (guild) {
-        await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+        await addToGuildXP(guild.guildName, earnedXp, message.member);
       }
     }
 

--- a/src/commands/rob.ts
+++ b/src/commands/rob.ts
@@ -1,6 +1,5 @@
 import { BaseMessageOptions, CommandInteraction, InteractionReplyOptions, Message, MessageEditOptions } from "discord.js";
 import redis from "../init/redis";
-import { NypsiClient } from "../models/Client";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants";
@@ -220,7 +219,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         const guild = await getGuildByUser(message.member);
 
         if (guild) {
-          await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+          await addToGuildXP(guild.guildName, earnedXp, message.member);
         }
       }
 

--- a/src/commands/rockpaperscissors.ts
+++ b/src/commands/rockpaperscissors.ts
@@ -1,6 +1,5 @@
 import { BaseMessageOptions, CommandInteraction, InteractionReplyOptions, Message, MessageEditOptions } from "discord.js";
 import * as shuffle from "shuffle-array";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -226,7 +225,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         const guild = await getGuildByUser(message.member);
 
         if (guild) {
-          await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+          await addToGuildXP(guild.guildName, earnedXp, message.member);
         }
       }
 

--- a/src/commands/roulette.ts
+++ b/src/commands/roulette.ts
@@ -6,7 +6,6 @@ import {
   Message,
   MessageEditOptions,
 } from "discord.js";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -292,7 +291,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         const guild = await getGuildByUser(message.member);
 
         if (guild) {
-          await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+          await addToGuildXP(guild.guildName, earnedXp, message.member);
         }
       }
 

--- a/src/commands/slots.ts
+++ b/src/commands/slots.ts
@@ -6,7 +6,6 @@ import {
   Message,
   MessageEditOptions,
 } from "discord.js";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -382,7 +381,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
         const guild = await getGuildByUser(message.member);
 
         if (guild) {
-          await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+          await addToGuildXP(guild.guildName, earnedXp, message.member);
         }
       }
 

--- a/src/commands/yablon.ts
+++ b/src/commands/yablon.ts
@@ -12,7 +12,6 @@ import {
   MessageEditOptions,
 } from "discord.js";
 import * as shuffle from "shuffle-array";
-import { NypsiClient } from "../models/Client.js";
 import { Categories, Command, NypsiCommandInteraction } from "../models/Command.js";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -414,7 +413,7 @@ async function playGame(message: Message | (NypsiCommandInteraction & CommandInt
         const guild = await getGuildByUser(message.member);
 
         if (guild) {
-          await addToGuildXP(guild.guildName, earnedXp, message.member, message.client as NypsiClient);
+          await addToGuildXP(guild.guildName, earnedXp, message.member);
         }
       }
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -17,6 +17,7 @@ export default {
       ROB_RADIO: "cd:rob-radio",
       SEX_CHASTITY: "cd:sex-chastity",
       AUCTION_WATCH: "cd:auctionwatch",
+      GUILD_CREATE: "cd:guildcreate",
     },
     cache: {
       SUPPORT: "cache:support",

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -82,4 +82,5 @@ export default {
   KOFI_PRODUCTS: products,
   EMBED_SUCCESS_COLOR: "#5efb8f" as ColorResolvable,
   EMBED_FAIL_COLOR: "#e4334f" as ColorResolvable,
+  MAX_GUILD_LEVEL: 69,
 };

--- a/src/utils/functions/economy/balance.ts
+++ b/src/utils/functions/economy/balance.ts
@@ -404,7 +404,7 @@ export async function calcNetWorth(member: GuildMember | string) {
 
   worth += Number(query.money);
   worth += Number(query.bank);
-  worth += Number(query.user.EconomyGuild?.balance / query.user.EconomyGuild?.members.length) || 0;
+  worth += Number(Number(query.user.EconomyGuild?.balance) / query.user.EconomyGuild?.members.length) || 0;
 
   for (const item of query.Inventory) {
     const auctionAvg = await getAuctionAverage(item.item);

--- a/src/utils/functions/economy/guilds.ts
+++ b/src/utils/functions/economy/guilds.ts
@@ -315,11 +315,11 @@ async function checkUpgrade(guild: EconomyGuild | string): Promise<boolean> {
 
     desc.push(` +**${cratesEarned}** basic crates`);
 
-    if (guild.level <= 5) {
+    if (guild.level < 5) {
       desc.push(" +**1**% multiplier");
     }
 
-    if (guild.level <= 10) {
+    if (guild.level < 10) {
       desc.push(" +**1** max xp gain");
     }
 

--- a/src/utils/functions/economy/guilds.ts
+++ b/src/utils/functions/economy/guilds.ts
@@ -168,7 +168,13 @@ export async function addToGuildXP(name: string, amount: number, member: GuildMe
 export async function getMaxMembersForGuild(name: string) {
   const guild = await getGuildByName(name);
 
-  return guild.level * 3;
+  let level = guild.level;
+
+  if (level > 10) level = 10;
+
+  const amount = 3 + Math.floor(level / 2) * 3;
+
+  return amount < 3 ? 3 : amount;
 }
 
 export async function getRequiredForGuildUpgrade(name: string): Promise<GuildUpgradeRequirements> {

--- a/src/utils/functions/economy/guilds.ts
+++ b/src/utils/functions/economy/guilds.ts
@@ -265,7 +265,7 @@ export async function removeMember(member: string, mode: RemoveMemberMode) {
 interface EconomyGuild {
   guildName: string;
   createdAt: Date;
-  balance: number;
+  balance: bigint;
   xp: number;
   level: number;
   motd: string;
@@ -277,7 +277,7 @@ interface EconomyGuildMember {
   userId: string;
   guildName: string;
   joinedAt: Date;
-  contributedMoney: number;
+  contributedMoney: bigint;
   contributedXp: number;
 }
 
@@ -289,7 +289,7 @@ async function checkUpgrade(guild: EconomyGuild | string): Promise<boolean> {
   if (guild.level >= Constants.MAX_GUILD_LEVEL) return;
   const requirements = await getRequiredForGuildUpgrade(guild.guildName);
 
-  if (guild.balance >= requirements.money && guild.xp >= requirements.xp) {
+  if (Number(guild.balance) >= requirements.money && guild.xp >= requirements.xp) {
     await prisma.economyGuild.update({
       where: {
         guildName: guild.guildName,

--- a/src/utils/functions/economy/guilds.ts
+++ b/src/utils/functions/economy/guilds.ts
@@ -178,8 +178,8 @@ export async function getRequiredForGuildUpgrade(name: string): Promise<GuildUpg
 
   const guild = await getGuildByName(name);
 
-  const baseMoney = 5000000 * Math.pow(guild.level, 2);
-  const baseXP = 1425 * Math.pow(guild.level, 2);
+  const baseMoney = 3000000 * Math.pow(guild.level, 2);
+  const baseXP = 1225 * Math.pow(guild.level, 2);
 
   const bonusMoney = 100000 * guild.members.length;
   const bonusXP = 75 * guild.members.length;

--- a/src/utils/functions/economy/guilds.ts
+++ b/src/utils/functions/economy/guilds.ts
@@ -287,7 +287,7 @@ async function checkUpgrade(guild: EconomyGuild | string, client: NypsiClient): 
     guild = await getGuildByName(guild);
   }
 
-  if (guild.level == 5) return;
+  if (guild.level >= Constants.MAX_GUILD_LEVEL) return;
   const requirements = await getRequiredForGuildUpgrade(guild.guildName);
 
   if (guild.balance >= requirements.money && guild.xp >= requirements.xp) {


### PR DESCRIPTION
adds guild deposit confirmation
reduces guild members per level
slight decrease to upgrade requirements
ups max level to 69 (practically impossible with current requirements)
prevents guild create abuse to get basic crates
