### PR TITLE
fix: modlog embeds not sending

### DIFF
--- a/src/utils/functions/moderation/logs.ts
+++ b/src/utils/functions/moderation/logs.ts
@@ -69,7 +69,7 @@ export async function addModLog(
     embed.addField("reason", command);
   }
 
-  await redis.lpush(`${Constants.redis.cache.guild.MODLOGS}${guild.id}`, JSON.stringify(embed.toJSON()));
+  await redis.lpush(`${Constants.redis.cache.guild.MODLOGS}:${guild.id}`, JSON.stringify(embed.toJSON()));
 }
 
 export async function addLog(guild: Guild, type: LogType, embed: CustomEmbed) {


### PR DESCRIPTION
modlog embeds wouldn't send when a moderation action was taken