### PR TITLE
fix: gems not adding your increment

### DIFF
--- a/src/commands/mines.ts
+++ b/src/commands/mines.ts
@@ -681,7 +681,7 @@ async function playGame(
         win += increment;
       } else {
         grid[location] = "gc";
-        win += 3;
+        win += increment + 3;
 
         const caught = Math.floor(Math.random() * 50);
 


### PR DESCRIPTION
gems would add 3 to your win total, instead of the increment + 3. for example, you'd win 3x on a 23 mine game instead of 15x+3x (18x)