### PR TITLE
fix: blue gem alias

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1126,7 +1126,7 @@
   "blue_rocks": {
     "id": "blue_rocks",
     "name": "blue rocks",
-    "aliases": ["blue", "meth", "C10H15N"],
+    "aliases": ["meth", "C10H15N"],
     "emoji": "<:nypsi_bluerock:1003408529954177144>",
     "longDesc": "https://youtu.be/Dbt-OfbQTpw?t=28",
     "rarity": 0,


### PR DESCRIPTION
blue gem now has "blue" as an alias because people are lazy and every other gem is like that