### PR TITLE
refactor: allow admin level 2 to ecoban

### DIFF
--- a/src/commands/ecoban.ts
+++ b/src/commands/ecoban.ts
@@ -2,11 +2,12 @@ import { CommandInteraction, Message } from "discord.js";
 import { Command, NypsiCommandInteraction } from "../models/Command";
 import Constants from "../utils/Constants";
 import { isEcoBanned, setEcoBan } from "../utils/functions/economy/utils";
+import { getAdminLevel } from "../utils/functions/users/admin";
 
 const cmd = new Command("ecoban", "ban an account from eco", "none");
 
 async function run(message: Message | (NypsiCommandInteraction & CommandInteraction), args: string[]) {
-  if (!Constants.ADMIN_IDS.includes(message.author.id)) return;
+  if (await getAdminLevel(message.author.id)) < 2) return;
 
   if (args.length == 0) {
     return message.channel.send({ content: "dumbass" });


### PR DESCRIPTION
allows level 2 admins to use $ecoban, as they can ecoban from the x menu and not the command