### PR TITLE
refactor: include discord server link on support cooldown

### DIFF
--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -51,7 +51,7 @@ export default async function messageCreate(message: Message) {
 
     if (await redis.exists(`${Constants.redis.cooldown.SUPPORT}:${message.author.id}`)) {
       return message.reply({
-        embeds: [new ErrorEmbed("you have created a support request recently, try again later")],
+        embeds: [new ErrorEmbed("you have created a support request recently, try again later.\nif you need support and don't want to wait, you can join the nypsi support server [here](https://discord.gg/hJTDNST)")],
       });
     }
 


### PR DESCRIPTION
this includes a link to the discord server even if the person is on a support request cooldown