### PR TITLE
fix: allow big mod to delete auctions

### DIFF
--- a/src/commands/auction.ts
+++ b/src/commands/auction.ts
@@ -579,6 +579,7 @@ async function run(message: Message | (NypsiCommandInteraction & CommandInteract
     if (roles.has("747056620688900139")) allow = true;
     if (roles.has("747059949770768475")) allow = true;
     if (roles.has("845613231229370429")) allow = true;
+    if (roles.has("1105179633919471707")) allow = true;
 
     if (!allow) return;
 


### PR DESCRIPTION
big mod wasn't added to the roles list that could delete auctions for some reason