### PR TITLE
fix: wildly inaccurate worker net calculation

### DIFF
--- a/src/utils/functions/economy/balance.ts
+++ b/src/utils/functions/economy/balance.ts
@@ -19,6 +19,7 @@ import { hasVoted } from "./vote";
 import { calcWorkerValues } from "./workers";
 import ms = require("ms");
 import _ = require("lodash");
+import { logger } from "../../logger";
 
 export async function getBalance(member: GuildMember | string) {
   let id: string;
@@ -837,7 +838,7 @@ export async function calcNetWorth(member: GuildMember | string, breakdown = fal
             ? baseWorkers[worker.workerId].prestige_requirement / 40
             : 1);
 
-        for (let i = upgrade.amount; i < upgrade.amount + 1; i++) {
+        for (let i = 0; i < upgrade.amount; i++) {
           const cost = baseCost + baseCost * i;
 
           totalCost += cost;
@@ -850,8 +851,11 @@ export async function calcNetWorth(member: GuildMember | string, breakdown = fal
 
     const { perItem } = await calcWorkerValues(worker);
 
+    
+    worth += baseWorkers[worker.workerId].cost;
     worth += worker.stored * perItem;
     workersBreakdown += worker.stored * perItem;
+    workersBreakdown += baseWorkers[worker.workerId].cost;
   }
 
   breakdownItems.set("workers", workersBreakdown);


### PR DESCRIPTION
you were only counting the price of the highest level upgrade purchased + didnt count price to buy the worker

(started with 300m)
before
![image](https://github.com/tekoh/nypsi/assets/52770460/427d99ab-a8fe-4805-977e-09f8dd6ac327)

after
![image](https://github.com/tekoh/nypsi/assets/52770460/eb34a2c7-693d-466d-bbcc-57fa313eb71b)
