### PR TITLE
feat: allow "all" in market order fulfilling

### DIFF
--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -1147,7 +1147,7 @@ async function run(
     let amount = args[2] ?? "1";
 
     if (amount.toLowerCase() == "all") {
-      const invAmount = inventory.find((i) => i.item == item.id).amount ?? 0;
+      const invAmount = inventory.count(item.id);
       const marketAmount = (await getMarketItemOrders(item.id, "buy", message.member.id)).reduce(
         (count, order) => Number(order.itemAmount) + count,
         0,
@@ -1168,8 +1168,6 @@ async function run(
         embeds: [new ErrorEmbed(`not enough ${item.plural} on the market`)],
       });
     }
-
-    const inventory = await getInventory(message.member);
 
     if (inventory.count(item.id) < parseInt(amount)) {
       return send({

--- a/src/interactions/market_partial.ts
+++ b/src/interactions/market_partial.ts
@@ -79,9 +79,7 @@ export default {
 
     if (input.toLowerCase() == "all") {
       if (order.orderType == "buy") {
-        input = (
-          (await getInventory(interaction.user.id)).find((i) => i.item == order.itemId)?.amount ?? 0
-        ).toString();
+        input = (await getInventory(interaction.user.id)).count(order.itemId).toString();
       } else {
         input = Number(order.itemAmount).toString();
 


### PR DESCRIPTION
has some logic to it as well

when doing "all" with $market buy (or market buy partial modal):
* get the most that you can afford, not necessarily the most in the order

example (bananas were 20m each with 10 on market):
![image](https://github.com/user-attachments/assets/015a2e28-2418-48cf-8401-f1328ead88e2)


when doing "all" with $market sell (or market sell partial modal):
* sell either the amount that you have or the amount in all orders (in modal, just the specific order), whichever is lower

example:
![image](https://github.com/user-attachments/assets/89c29062-df23-4b06-b005-2c3cab19548d)
