### PR TITLE
fix: only show loot pool page buttons when needed

### DIFF
--- a/src/utils/functions/economy/item_info.ts
+++ b/src/utils/functions/economy/item_info.ts
@@ -206,20 +206,22 @@ export async function runItemInfo(
 
       let target = subTab === undefined ? tabs[tabName].embed : tabs[tabName].subEmbeds[subTab];
       if (target instanceof Array) {
-        rows.push(
-          new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
-            new ButtonBuilder()
-              .setCustomId("⬅")
-              .setLabel("back")
-              .setStyle(ButtonStyle.Primary)
-              .setDisabled((page ?? 0) <= 0),
-            new ButtonBuilder()
-              .setCustomId("➡")
-              .setLabel("next")
-              .setStyle(ButtonStyle.Primary)
-              .setDisabled((page ?? 0) >= target.length - 1),
-          ),
-        );
+        if (target.length > 1) {
+          rows.push(
+            new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+              new ButtonBuilder()
+                .setCustomId("⬅")
+                .setLabel("back")
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled((page ?? 0) <= 0),
+              new ButtonBuilder()
+                .setCustomId("➡")
+                .setLabel("next")
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled((page ?? 0) >= target.length - 1),
+            ),
+          );
+        }
         target = target[page ?? 0];
       }
       if (tabs[tabName].widgets !== undefined) {


### PR DESCRIPTION
crates with only 1 page like gem crate dont need next/back buttons

![image](https://github.com/user-attachments/assets/0d609df5-5537-44f8-b398-f5d3f292a4a4)
