### PR TITLE
fix: incorrect item stats

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -472,7 +472,6 @@ async function run(
     });
   } else {
     if (itemFunctions.has(selected.id)) {
-      await addStat(message.member, selected.id);
       return itemFunctions.get(selected.id).run(message, args);
     } else {
       return send({

--- a/src/models/ItemUse.ts
+++ b/src/models/ItemUse.ts
@@ -1,4 +1,10 @@
-import { CommandInteraction } from "discord.js";
+import {
+  BaseMessageOptions,
+  CommandInteraction,
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+  Message,
+} from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "./Command";
 
 export class ItemUse {
@@ -17,5 +23,38 @@ export class ItemUse {
   ) {
     this.itemId = itemId;
     this.run = func;
+  }
+
+  static async send(
+    message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
+    data: BaseMessageOptions | InteractionReplyOptions,
+  ): Promise<Message> {
+    if (!(message instanceof Message)) {
+      let usedNewMessage = false;
+      let res;
+
+      if (message.deferred) {
+        res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+          usedNewMessage = true;
+          return await message.channel.send(data as BaseMessageOptions);
+        });
+      } else {
+        res = await message.reply(data as InteractionReplyOptions).catch(() => {
+          return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+            usedNewMessage = true;
+            return await message.channel.send(data as BaseMessageOptions);
+          });
+        });
+      }
+
+      if (usedNewMessage && res instanceof Message) return res;
+
+      const replyMsg = await message.fetchReply();
+      if (replyMsg instanceof Message) {
+        return replyMsg;
+      }
+    } else {
+      return await message.channel.send(data as BaseMessageOptions);
+    }
   }
 }

--- a/src/scheduled/jobs/streaks.ts
+++ b/src/scheduled/jobs/streaks.ts
@@ -1,4 +1,5 @@
 import dayjs = require("dayjs");
+import { ClusterManager } from "discord-hybrid-sharding";
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -11,30 +12,35 @@ import { CustomEmbed } from "../../models/EmbedBuilders";
 import { Job } from "../../types/Jobs";
 import { NotificationPayload } from "../../types/Notification";
 import Constants from "../../utils/Constants";
-import { removeInventoryItem } from "../../utils/functions/economy/inventory";
-import { percentChance } from "../../utils/functions/random";
+import {
+  gemBreak,
+  getInventory,
+  removeInventoryItem,
+} from "../../utils/functions/economy/inventory";
+import { addStat } from "../../utils/functions/economy/stats";
+import { pluralize } from "../../utils/functions/string";
 import { addNotificationToQueue } from "../../utils/functions/users/notifications";
 import pAll = require("p-all");
 
 export default {
   name: "streaks",
   cron: "0 0 * * *",
-  async run(log) {
+  async run(log, manager) {
     if (await redis.exists("nypsi:streakpause")) {
       log("streaks paused");
       return;
     }
 
-    const dailyStreak = await doDailyStreaks();
+    const dailyStreak = await doDailyStreaks(manager);
 
     log(`${dailyStreak} daily streak notifications sent`);
 
-    const voteStreak = await doVoteStreaks();
+    const voteStreak = await doVoteStreaks(manager);
     log(`${voteStreak} vote streak notifications sent`);
   },
 } satisfies Job;
 
-async function doDailyStreaks() {
+async function doDailyStreaks(manager: ClusterManager) {
   const limit = dayjs().subtract(1, "day").subtract(1, "hours").toDate();
 
   const users = await prisma.economy.findMany({
@@ -75,12 +81,14 @@ async function doDailyStreaks() {
       "<:nypsi_gem_white:1046933670436552725> white gems have a chance to protect your streaks. make sure to do /daily to continue your streak",
     );
 
-  const whiteGemBrokeEmbed = new CustomEmbed()
-    .setColor(Constants.EMBED_FAIL_COLOR)
-    .setTitle("your white gem has shattered")
-    .setDescription(
-      "<:nypsi_gem_white:1046933670436552725> the power exerted by your white gem to save your streak has unfortunately caused it to shatter...",
-    );
+  const whiteGemBrokeEmbed = (amount: number) => {
+    return new CustomEmbed()
+      .setColor(Constants.EMBED_FAIL_COLOR)
+      .setTitle("your white gem has shattered")
+      .setDescription(
+        `<:nypsi_gem_white:1046933670436552725> the power exerted by your white gem to save your streak has unfortunately caused it to shatter into ${amount} ${pluralize("piece", amount)}`,
+      );
+  };
 
   const resetEmbed = new CustomEmbed()
     .setColor(Constants.EMBED_FAIL_COLOR)
@@ -93,25 +101,32 @@ async function doDailyStreaks() {
   const promises: (() => Promise<any>)[] = [];
 
   for (const user of users) {
+    const inventory = await getInventory(user.userId);
+
     promises.push(async () => {
-      if (user.Inventory.find((i) => i.item == "calendar")?.amount > 0) {
+      if (inventory.has("calendar")) {
         if (user.user.DMSettings?.other)
           notifications.push({ memberId: user.userId, payload: { embed: calendarSavedEmbed } });
 
         await removeInventoryItem(user.userId, "calendar", 1);
+        await addStat(user.userId, "calendar");
 
         return;
-      } else if (user.Inventory.find((i) => i.item == "white_gem")?.amount > 0n) {
+      } else if (inventory.hasGem("white_gem")) {
         const gemSaveChance = Math.floor(Math.random() * 10);
 
         if (gemSaveChance < 5) {
           notifications.push({ memberId: user.userId, payload: { embed: gemSavedEmbed } });
 
-          if (percentChance(7)) {
-            await removeInventoryItem(user.userId, "calendar", 1);
+          const res = await gemBreak(user.userId, 7, "white_gem", manager, true, false);
 
-            notifications.push({ memberId: user.userId, payload: { embed: whiteGemBrokeEmbed } });
+          if (res) {
+            notifications.push({
+              memberId: user.userId,
+              payload: { embed: whiteGemBrokeEmbed(res.shards).setFooter({ text: res.footerMsg }) },
+            });
           }
+
           return;
         }
       }
@@ -136,7 +151,7 @@ async function doDailyStreaks() {
   return notifications.length;
 }
 
-async function doVoteStreaks() {
+async function doVoteStreaks(manager: ClusterManager) {
   const limit = dayjs().subtract(1, "day").subtract(1, "hours").toDate();
 
   const users = await prisma.economy.findMany({
@@ -178,12 +193,14 @@ async function doVoteStreaks() {
       "<:nypsi_gem_white:1046933670436552725> white gems have a chance to protect your streak. make sure to vote to continue your streak",
     );
 
-  const whiteGemBrokeEmbed = new CustomEmbed()
-    .setColor(Constants.EMBED_FAIL_COLOR)
-    .setTitle("your white gem has shattered")
-    .setDescription(
-      "<:nypsi_gem_white:1046933670436552725> the power exerted by your white gem to save your streak has unfortunately caused it to shatter...",
-    );
+  const whiteGemBrokeEmbed = (amount: number) => {
+    return new CustomEmbed()
+      .setColor(Constants.EMBED_FAIL_COLOR)
+      .setTitle("your white gem has shattered")
+      .setDescription(
+        `<:nypsi_gem_white:1046933670436552725> the power exerted by your white gem to save your streak has unfortunately caused it to shatter into ${amount} ${pluralize("piece", amount)}`,
+      );
+  };
 
   const resetEmbed = new CustomEmbed()
     .setColor(Constants.EMBED_FAIL_COLOR)
@@ -215,8 +232,10 @@ async function doVoteStreaks() {
   const promises: (() => Promise<any>)[] = [];
 
   for (const user of users) {
+    const inventory = await getInventory(user.userId);
+
     promises.push(async () => {
-      if (user.Inventory.find((i) => i.item == "calendar")?.amount > 0) {
+      if (inventory.has("calendar")) {
         if (user.user.DMSettings?.other) {
           if (user.user.DMSettings.voteReminder) {
             notifications.push({
@@ -232,9 +251,10 @@ async function doVoteStreaks() {
         }
 
         await removeInventoryItem(user.userId, "calendar", 1);
+        await addStat(user.userId, "calendar");
 
         return;
-      } else if (user.Inventory.find((i) => i.item == "white_gem")?.amount > 0n) {
+      } else if (inventory.hasGem("white_gem")) {
         const gemSaveChance = Math.floor(Math.random() * 10);
 
         if (gemSaveChance < 5) {
@@ -252,23 +272,30 @@ async function doVoteStreaks() {
             }
           }
 
-          if (percentChance(7)) {
-            await removeInventoryItem(user.userId, "calendar", 1);
+          const res = await gemBreak(user.userId, 7, "white_gem", manager, true, false);
 
+          if (res) {
             if (user.user.DMSettings?.other) {
               if (user.user.DMSettings.voteReminder) {
                 notifications.push({
                   memberId: user.userId,
-                  payload: { embed: whiteGemBrokeEmbed, components: voteRow },
+                  payload: {
+                    embed: whiteGemBrokeEmbed(res.shards).setFooter({ text: res.footerMsg }),
+                    components: voteRow,
+                  },
                 });
               } else {
                 notifications.push({
                   memberId: user.userId,
-                  payload: { embed: whiteGemBrokeEmbed, components: remindersRow },
+                  payload: {
+                    embed: whiteGemBrokeEmbed(res.shards).setFooter({ text: res.footerMsg }),
+                    components: remindersRow,
+                  },
                 });
               }
             }
           }
+
           return;
         }
       }

--- a/src/utils/functions/economy/farm.ts
+++ b/src/utils/functions/economy/farm.ts
@@ -8,6 +8,7 @@ import { getUserId, MemberResolvable } from "../member";
 import { addProgress } from "./achievements";
 import { addEventProgress } from "./events";
 import { addInventoryItem, gemBreak, getInventory, removeInventoryItem } from "./inventory";
+import { addStat } from "./stats";
 import { getPlantsData, getPlantUpgrades, getUpgradesData } from "./utils";
 import dayjs = require("dayjs");
 import ms = require("ms");
@@ -385,6 +386,7 @@ export async function fertiliseFarm(member: MemberResolvable): Promise<{
   });
 
   await removeInventoryItem(member, "fertiliser", Math.ceil(possible.length / 3));
+  await addStat(member, "fertiliser", Math.ceil(possible.length / 3));
   await redis.del(`${Constants.redis.cache.economy.farm}:${getUserId(member)}`);
 
   return { done: possible.length, dead };

--- a/src/utils/functions/economy/items/bitch.ts
+++ b/src/utils/functions/economy/items/bitch.ts
@@ -1,53 +1,20 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
 import { pluralize } from "../../string";
 import { getInventory } from "../inventory";
+import { addStat } from "../stats";
 import { getItems } from "../utils";
 
 module.exports = new ItemUse(
   "bitch",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
+    await addStat(message.member, "bitch");
 
     const inventory = await getInventory(message.member);
 
-    return send({
+    return ItemUse.send(message, {
       embeds: [
         new CustomEmbed(
           message.member,

--- a/src/utils/functions/economy/items/calendar.ts
+++ b/src/utils/functions/economy/items/calendar.ts
@@ -1,10 +1,4 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
@@ -12,37 +6,7 @@ import { ItemUse } from "../../../../models/ItemUse";
 module.exports = new ItemUse(
   "calendar",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
-    return send({
+    return ItemUse.send(message, {
       embeds: [new CustomEmbed(message.member, "calendars will be used automatically")],
     });
   },

--- a/src/utils/functions/economy/items/dave.ts
+++ b/src/utils/functions/economy/items/dave.ts
@@ -1,13 +1,8 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
+import { addStat } from "../stats";
 
 const responses = [
   "AHHHH DONT EAT ME PLSSS",
@@ -33,36 +28,6 @@ const responses = [
 module.exports = new ItemUse(
   "dave",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const chosen = responses[Math.floor(Math.random() * responses.length)];
 
     const embed = new CustomEmbed(message.member);
@@ -70,7 +35,9 @@ module.exports = new ItemUse(
     if (chosen.startsWith("img:")) embed.setImage(chosen.substring(4, chosen.length));
     else embed.setDescription(chosen);
 
-    return send({
+    await addStat(message.member, "dave");
+
+    return ItemUse.send(message, {
       embeds: [embed],
     });
   },

--- a/src/utils/functions/economy/items/fertiliser.ts
+++ b/src/utils/functions/economy/items/fertiliser.ts
@@ -1,10 +1,4 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
@@ -13,44 +7,15 @@ import { fertiliseFarm, getFarm } from "../farm";
 module.exports = new ItemUse(
   "fertiliser",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const farm = await getFarm(message.author.id);
 
-    if (farm.length === 0) return send({ embeds: [new ErrorEmbed("you have no plants")] });
+    if (farm.length === 0)
+      return ItemUse.send(message, { embeds: [new ErrorEmbed("you have no plants")] });
 
     const res = await fertiliseFarm(message.author.id);
 
     if (res.msg === "no fertiliser") {
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new ErrorEmbed(
             "you don't have any fertiliser" +
@@ -59,7 +24,7 @@ module.exports = new ItemUse(
         ],
       });
     } else if (res.msg === "no need") {
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new ErrorEmbed(
             "none of your plants need fertiliser" +
@@ -70,7 +35,7 @@ module.exports = new ItemUse(
     }
 
     if (res.done) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,

--- a/src/utils/functions/economy/items/football.ts
+++ b/src/utils/functions/economy/items/football.ts
@@ -1,13 +1,8 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
+import { addStat } from "../stats";
 
 const responses = [
   "img:https://c.tenor.com/xycFj0Sr_2IAAAAd/tenor.gif",
@@ -18,36 +13,6 @@ const responses = [
 module.exports = new ItemUse(
   "football",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const chosen = responses[Math.floor(Math.random() * responses.length)];
 
     const embed = new CustomEmbed(message.member);
@@ -55,7 +20,9 @@ module.exports = new ItemUse(
     if (chosen.startsWith("img:")) embed.setImage(chosen.substring(4, chosen.length));
     else embed.setDescription(chosen);
 
-    return send({
+    await addStat(message.member, "football");
+
+    return ItemUse.send(message, {
       embeds: [embed],
     });
   },

--- a/src/utils/functions/economy/items/gold_credit.ts
+++ b/src/utils/functions/economy/items/gold_credit.ts
@@ -1,13 +1,9 @@
 import {
   ActionRowBuilder,
-  BaseMessageOptions,
   ButtonBuilder,
   ButtonStyle,
   CommandInteraction,
   Interaction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
   MessageActionRowComponentBuilder,
 } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
@@ -23,6 +19,7 @@ import {
   setTier,
 } from "../../premium/premium";
 import { getInventory, removeInventoryItem } from "../inventory";
+import { addStat } from "../stats";
 import dayjs = require("dayjs");
 
 const GOLD_TIER = 3;
@@ -30,40 +27,12 @@ const GOLD_TIER = 3;
 module.exports = new ItemUse(
   "gold_credit",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const currentTier = await getTier(message.author.id);
 
     if (currentTier > GOLD_TIER)
-      return send({ embeds: [new ErrorEmbed("your current premium tier is higher than gold")] });
+      return ItemUse.send(message, {
+        embeds: [new ErrorEmbed("your current premium tier is higher than gold")],
+      });
 
     if (currentTier == GOLD_TIER) {
       const profile = await getPremiumProfile(message.author.id);
@@ -71,8 +40,9 @@ module.exports = new ItemUse(
       const credits = await getCredits(message.author.id);
       await setCredits(message.author.id, credits + 7);
       await removeInventoryItem(message.member, "gold_credit", 1);
+      await addStat(message.member, "gold_credit");
 
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -87,10 +57,11 @@ module.exports = new ItemUse(
       });
     } else if (currentTier === 0) {
       await removeInventoryItem(message.member, "gold_credit", 1);
+      await addStat(message.member, "gold_credit");
       await addMember(message.author.id, GOLD_TIER, new Date());
       await setCredits(message.author.id, 7);
 
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -99,7 +70,7 @@ module.exports = new ItemUse(
         ],
       });
     } else {
-      const msg = await send({
+      const msg = await ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -129,6 +100,7 @@ module.exports = new ItemUse(
         return res.editReply({ embeds: [new ErrorEmbed("lol!")] });
       }
       await removeInventoryItem(message.member, "gold_credit", 1);
+      await addStat(message.member, "gold_credit");
       await setTier(message.author.id, GOLD_TIER);
       await setExpireDate(message.author.id, new Date());
       await setCredits(message.author.id, 7);

--- a/src/utils/functions/economy/items/lock_pick.ts
+++ b/src/utils/functions/economy/items/lock_pick.ts
@@ -1,8 +1,6 @@
 import {
-  BaseMessageOptions,
   CommandInteraction,
   InteractionEditReplyOptions,
-  InteractionReplyOptions,
   Message,
   MessageEditOptions,
 } from "discord.js";
@@ -19,6 +17,7 @@ import { getDmSettings } from "../../users/notifications";
 import { hasPadlock, setPadlock } from "../balance";
 import { removeInventoryItem } from "../inventory";
 import { isPassive } from "../passive";
+import { addStat } from "../stats";
 import ms = require("ms");
 
 module.exports = new ItemUse(
@@ -27,22 +26,6 @@ module.exports = new ItemUse(
     message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
     args: string[],
   ) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        if (message.deferred) {
-          await message.editReply(data as InteractionEditReplyOptions);
-        } else {
-          await message.reply(data as InteractionReplyOptions);
-        }
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const edit = async (data: MessageEditOptions, msg: Message) => {
       if (!(message instanceof Message)) {
         await message.editReply(data as InteractionEditReplyOptions);
@@ -53,7 +36,7 @@ module.exports = new ItemUse(
     };
 
     if ((await isUserBlacklisted(message.guild.ownerId)).blacklisted) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new ErrorEmbed(
             `the owner of this server (${(await message.guild.members.fetch(message.guild.ownerId)).toString()}) is blacklisted\n` +
@@ -64,7 +47,7 @@ module.exports = new ItemUse(
     }
 
     if (args.length == 1) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed("/use lockpick <member>")],
       });
     }
@@ -72,7 +55,7 @@ module.exports = new ItemUse(
     const lockPickTarget = await getMember(message.guild, args[1]);
 
     if (!lockPickTarget) {
-      return send({ embeds: [new ErrorEmbed("invalid user")] });
+      return ItemUse.send(message, { embeds: [new ErrorEmbed("invalid user")] });
     }
 
     if (message.member == lockPickTarget) {
@@ -81,7 +64,7 @@ module.exports = new ItemUse(
       ) {
         await redis.del(`${Constants.redis.cooldown.SEX_CHASTITY}:${message.author.id}`);
 
-        const msg = await send({
+        const msg = await ItemUse.send(message, {
           embeds: [new CustomEmbed(message.member, "picking chastity cage...")],
         });
 
@@ -99,11 +82,11 @@ module.exports = new ItemUse(
           msg,
         );
       }
-      return send({ embeds: [new ErrorEmbed("invalid user")] });
+      return ItemUse.send(message, { embeds: [new ErrorEmbed("invalid user")] });
     }
 
     if ((await getDisabledCommands(message.guild)).includes("rob")) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed(`lockpicks have been disabled in ${message.guild.name}`)],
       });
     }
@@ -114,21 +97,23 @@ module.exports = new ItemUse(
         `${Constants.redis.cache.guild.RECENTLY_ATTACKED}:${message.guildId}:${lockPickTarget.id}`,
       ))
     ) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed(`${lockPickTarget.toString()} cannot be robbed yet`)],
       });
     }
 
     if (await isPassive(lockPickTarget))
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed(`${lockPickTarget.toString()} is currently in passive mode`)],
       });
 
     if (await isPassive(message.member))
-      return send({ embeds: [new ErrorEmbed("you are currently in passive mode")] });
+      return ItemUse.send(message, {
+        embeds: [new ErrorEmbed("you are currently in passive mode")],
+      });
 
     if (!(await hasPadlock(lockPickTarget))) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed("this member doesn't have a padlock")],
       });
     }
@@ -142,6 +127,7 @@ module.exports = new ItemUse(
 
     await Promise.all([
       removeInventoryItem(message.member, "lock_pick", 1),
+      addStat(message.member, "lock_pick"),
       setPadlock(lockPickTarget, false),
     ]);
 
@@ -162,7 +148,7 @@ module.exports = new ItemUse(
       await lockPickTarget.send({ embeds: [targetEmbed] });
     }
 
-    const msg = await send({
+    const msg = await ItemUse.send(message, {
       embeds: [
         new CustomEmbed(message.member, `picking **${lockPickTarget.user.username}**'s padlock...`),
       ],

--- a/src/utils/functions/economy/items/lottery_ticket.ts
+++ b/src/utils/functions/economy/items/lottery_ticket.ts
@@ -1,10 +1,4 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
@@ -13,37 +7,7 @@ import { getPrefix } from "../../guilds/utils";
 module.exports = new ItemUse(
   "lottery_ticket",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
-    return send({
+    return ItemUse.send(message, {
       embeds: [
         new CustomEmbed(
           message.member,

--- a/src/utils/functions/economy/items/padlock.ts
+++ b/src/utils/functions/economy/items/padlock.ts
@@ -1,60 +1,28 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
 import { hasPadlock, setPadlock } from "../balance";
 import { removeInventoryItem } from "../inventory";
+import { addStat } from "../stats";
 
 module.exports = new ItemUse(
   "padlock",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     if (await hasPadlock(message.member)) {
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed("you already have a padlock on your balance")],
       });
     }
 
     await Promise.all([
       removeInventoryItem(message.member, "padlock", 1),
+      addStat(message.member, "padlock"),
       setPadlock(message.member, true),
     ]);
 
-    return send({ embeds: [new CustomEmbed(message.member, "✅ your padlock has been applied")] });
+    return ItemUse.send(message, {
+      embeds: [new CustomEmbed(message.member, "✅ your padlock has been applied")],
+    });
   },
 );

--- a/src/utils/functions/economy/items/platinum_credit.ts
+++ b/src/utils/functions/economy/items/platinum_credit.ts
@@ -1,13 +1,9 @@
 import {
   ActionRowBuilder,
-  BaseMessageOptions,
   ButtonBuilder,
   ButtonStyle,
   CommandInteraction,
   Interaction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
   MessageActionRowComponentBuilder,
 } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
@@ -23,6 +19,7 @@ import {
   setTier,
 } from "../../premium/premium";
 import { getInventory, removeInventoryItem } from "../inventory";
+import { addStat } from "../stats";
 import dayjs = require("dayjs");
 
 const PLAT_TIER = 4;
@@ -30,40 +27,10 @@ const PLAT_TIER = 4;
 module.exports = new ItemUse(
   "platinum_credit",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
     const currentTier = await getTier(message.author.id);
 
     if (currentTier > PLAT_TIER)
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed("your current premium tier is higher than platinum")],
       });
 
@@ -73,8 +40,9 @@ module.exports = new ItemUse(
       const credits = await getCredits(message.author.id);
       await setCredits(message.author.id, credits + 7);
       await removeInventoryItem(message.member, "platinum_credit", 1);
+      await addStat(message.member, "platinum_credit");
 
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -93,8 +61,9 @@ module.exports = new ItemUse(
       await setCredits(message.author.id, 7);
 
       await removeInventoryItem(message.member, "platinum_credit", 1);
+      await addStat(message.member, "platinum_credit");
 
-      return send({
+      return ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -103,7 +72,7 @@ module.exports = new ItemUse(
         ],
       });
     } else {
-      const msg = await send({
+      const msg = await ItemUse.send(message, {
         embeds: [
           new CustomEmbed(
             message.member,
@@ -135,6 +104,7 @@ module.exports = new ItemUse(
       }
 
       await removeInventoryItem(message.member, "platinum_credit", 1);
+      await addStat(message.member, "platinum_credit");
 
       await setTier(message.author.id, PLAT_TIER);
       await setExpireDate(message.author.id, new Date());

--- a/src/utils/functions/economy/items/rick_astley.ts
+++ b/src/utils/functions/economy/items/rick_astley.ts
@@ -1,10 +1,4 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import redis from "../../../../init/redis";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../../../../models/EmbedBuilders";
@@ -12,6 +6,7 @@ import { ItemUse } from "../../../../models/ItemUse";
 import Constants from "../../../Constants";
 import { getMember } from "../../member";
 import { removeInventoryItem } from "../inventory";
+import { addStat } from "../stats";
 
 module.exports = new ItemUse(
   "rick_astley",
@@ -19,52 +14,24 @@ module.exports = new ItemUse(
     message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
     args: string[],
   ) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
-
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
-    if (args.length === 1) return send({ embeds: [new ErrorEmbed("invalid member")] });
+    if (args.length === 1)
+      return ItemUse.send(message, { embeds: [new ErrorEmbed("invalid member")] });
 
     const target = await getMember(message.guild, args.slice(1, args.length).join(" "));
 
-    if (!target) return send({ embeds: [new ErrorEmbed("invalid member")] });
+    if (!target) return ItemUse.send(message, { embeds: [new ErrorEmbed("invalid member")] });
 
     if (await redis.exists(`${Constants.redis.nypsi.RICKROLL}:${target.user.id}`))
-      return send({
+      return ItemUse.send(message, {
         embeds: [new ErrorEmbed(`${target.user.username} already has a rick roll queued`)],
       });
 
     await removeInventoryItem(message.member, "rick_astley", 1);
+    await addStat(message.member, "rick_astley");
 
     await redis.set(`${Constants.redis.nypsi.RICKROLL}:${target.user.id}`, message.author.id);
 
-    return send({
+    return ItemUse.send(message, {
       embeds: [
         new CustomEmbed(
           message.member,

--- a/src/utils/functions/economy/items/teddy.ts
+++ b/src/utils/functions/economy/items/teddy.ts
@@ -1,48 +1,15 @@
-import {
-  BaseMessageOptions,
-  CommandInteraction,
-  InteractionEditReplyOptions,
-  InteractionReplyOptions,
-  Message,
-} from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { NypsiCommandInteraction, NypsiMessage } from "../../../../models/Command";
 import { CustomEmbed } from "../../../../models/EmbedBuilders";
 import { ItemUse } from "../../../../models/ItemUse";
+import { addStat } from "../stats";
 
 module.exports = new ItemUse(
   "teddy",
   async (message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) => {
-    const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
-      if (!(message instanceof Message)) {
-        let usedNewMessage = false;
-        let res;
+    await addStat(message.member, "teddy");
 
-        if (message.deferred) {
-          res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-            usedNewMessage = true;
-            return await message.channel.send(data as BaseMessageOptions);
-          });
-        } else {
-          res = await message.reply(data as InteractionReplyOptions).catch(() => {
-            return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
-              usedNewMessage = true;
-              return await message.channel.send(data as BaseMessageOptions);
-            });
-          });
-        }
-
-        if (usedNewMessage && res instanceof Message) return res;
-
-        const replyMsg = await message.fetchReply();
-        if (replyMsg instanceof Message) {
-          return replyMsg;
-        }
-      } else {
-        return await message.channel.send(data as BaseMessageOptions);
-      }
-    };
-
-    return send({
+    return ItemUse.send(message, {
       embeds: [
         new CustomEmbed(message.member, "you cuddle your teddy bear").setImage(
           "https://c.tenor.com/QGoHlSF2cSAAAAAM/hug-milk-and-mocha.gif",


### PR DESCRIPTION
fixes incorrect item stats:
* **bob** only giving 1 use when using multiple
* **credits, reroll, chastity cage, handcuffs, lockpick, lottery ticket, mask, padlock, radio, rick** adding to stats when they weren't fully used
* **calendar** now gives uses when saving streaks, not when getting info msg in `$use calendar`

made streaks actually shatter white gem on gem streak save instead of setting calendars to -1

also, moved send embed for all items into ItemUse so its not duplicated in each