### PR TITLE
restore old scratchie color functionality

### DIFF
--- a/src/utils/functions/economy/scratchies.ts
+++ b/src/utils/functions/economy/scratchies.ts
@@ -65,7 +65,7 @@ export default class ScratchCard {
 
     const rows: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [];
 
-    const labelButton = (button: ButtonBuilder, result: LootPoolResult, end = false) => {
+    const labelButton = (button: ButtonBuilder, result: LootPoolResult) => {
       if (Object.hasOwn(result, "item")) {
         button.setEmoji(items[result.item].emoji);
       } else if (Object.hasOwn(result, "xp")) {
@@ -99,7 +99,6 @@ export default class ScratchCard {
         button.setEmoji("🔮");
       } else {
         button.setLabel("\u200B");
-        if (!end) button.setStyle(ButtonStyle.Danger);
       }
     };
 
@@ -117,7 +116,7 @@ export default class ScratchCard {
           button.setDisabled(true);
           button.setStyle(ButtonStyle.Secondary);
 
-          if (end) button.setStyle(ButtonStyle.Danger);
+          if (end || !Object.keys(col.result).length) button.setStyle(ButtonStyle.Danger);
 
           labelButton(button, col.result);
         } else if (end) {
@@ -127,7 +126,7 @@ export default class ScratchCard {
           if (col.clicks === 2) button.setStyle(ButtonStyle.Success);
           if (col.clicks === 1) button.setStyle(ButtonStyle.Danger);
 
-          labelButton(button, col.result, true);
+          labelButton(button, col.result);
         } else {
           button.setStyle(ButtonStyle.Secondary);
           button.setLabel("\u200B");


### PR DESCRIPTION
with your recent change, empty spaces no longer appeared red during the game when clicked, which 3/3 people didnt like (me, will, snow)
<img width="437" height="325" alt="image" src="https://github.com/user-attachments/assets/ffa49708-5696-456c-a715-b8c446ca65f2" />

with this, it works how it used to

red during game
<img width="446" height="360" alt="image" src="https://github.com/user-attachments/assets/15fbc59f-4720-472b-a87e-de231b2dcad7" />

non clicked ones dont become red
<img width="453" height="376" alt="image" src="https://github.com/user-attachments/assets/2f9f9fdc-2fe1-441d-8c8d-e838a39aa9a6" />

closes #2121
