### PR TITLE
feat: exclude levelup task with max prestige

### DIFF
--- a/data/tasks.json
+++ b/data/tasks.json
@@ -131,6 +131,9 @@
       "id:nypsi_crate:1",
       "id:dabloon:125"
     ],
+    "exclude": [
+      "max_prestige"
+    ],
     "type": "weekly"
   },
   "gamble_weekly": {

--- a/src/types/Tasks.ts
+++ b/src/types/Tasks.ts
@@ -5,5 +5,6 @@ export interface Task {
   complete_gif?: string;
   target: number[]; // random from the list;
   prizes: string[]; // random prize will be chosen. in format of (id/money/xp/karma):(item/amount):(amount if item)
+  exclude?: string[];
   type: "daily" | "weekly";
 }

--- a/src/utils/functions/economy/tasks.ts
+++ b/src/utils/functions/economy/tasks.ts
@@ -14,7 +14,8 @@ import { addProgress } from "./achievements";
 import { addBalance } from "./balance";
 import { addToGuildXP, getGuildName } from "./guilds";
 import { addInventoryItem } from "./inventory";
-import { getItems, getTasksData, isEcoBanned, userExists } from "./utils";
+import { getPrestige } from "./levelling";
+import { getItems, getTasksData, isEcoBanned, maxPrestige, userExists } from "./utils";
 import { addXp } from "./xp";
 
 const taskGeneration = new Map<string, number>();
@@ -51,8 +52,12 @@ async function generateDailyTasks(member: MemberResolvable, count: number) {
 }
 
 async function generateWeeklyTasks(member: MemberResolvable, count: number) {
-  const tasks = Object.values(getTasksData()).filter((i) => i.type === "weekly");
+  let tasks = Object.values(getTasksData()).filter((i) => i.type === "weekly");
   const userId = getUserId(member);
+
+  if ((await getPrestige(member)) >= maxPrestige) {
+    tasks = tasks.filter((i) => !i.exclude?.includes("max_prestige"));
+  }
 
   const usersTasks: Task[] = [];
 


### PR DESCRIPTION
closes #2332 

tested, works fine

made tasks.json have an "exclude" property so this can be easily expanded on if needed in the future