### PR TITLE
fix: use the correct month for valentines day bonus

### DIFF
--- a/src/utils/functions/economy/utils.ts
+++ b/src/utils/functions/economy/utils.ts
@@ -773,7 +773,7 @@ export async function doDaily(
 
     const today = dayjs().set("hour", 0).set("minute", 0).set("second", 0).set("millisecond", 0);
 
-    if (today.date() === 14 && today.month() === 2) {
+    if (today.date() === 14 && today.month() === 1) {
       valentinesBonus = true;
 
       totalCards += 2;


### PR DESCRIPTION
did you forget to read this silly
<img width="474" height="159" alt="image" src="https://github.com/user-attachments/assets/2c5e85ad-ebd8-48fe-b04f-e69e4b49acb0" />


also id say dont merge this till tomorrow so people can get the bonuses they missed last month