### PR TITLE
fix: white shattering while saving streak embed not sending

### DIFF
--- a/src/scheduled/jobs/streaks.ts
+++ b/src/scheduled/jobs/streaks.ts
@@ -84,7 +84,7 @@ async function doDailyStreaks(manager: ClusterManager) {
         `<:nypsi_gem_white:1046933670436552725> the power exerted by your white gem to save your streak has unfortunately caused it to shatter into ${amount} ${pluralize("piece", amount)}`,
       );
 
-    return footer ? embed.setFooter({text: footer}) : embed;
+    return footer ? embed.setFooter({ text: footer }) : embed;
   };
 
   const resetEmbed = new CustomEmbed()


### PR DESCRIPTION
should be able to just reload jobs to fix