### PR TITLE
feat: use checkbox for market confirmation

### DIFF
--- a/src/utils/functions/economy/market.ts
+++ b/src/utils/functions/economy/market.ts
@@ -4,14 +4,13 @@ import {
   ButtonBuilder,
   ButtonInteraction,
   ButtonStyle,
+  CheckboxGroupBuilder,
   LabelBuilder,
   MessageActionRowComponentBuilder,
   MessageFlags,
   ModalBuilder,
   ModalSubmitInteraction,
   TextChannel,
-  TextInputBuilder,
-  TextInputStyle,
 } from "discord.js";
 import { Market, MarketWatch, OrderType, Prisma, PrismaClient } from "#generated/prisma";
 import prisma from "../../../init/database";
@@ -1188,18 +1187,21 @@ export async function showMarketConfirmationModal(
   const modal = new ModalBuilder().setCustomId(id).setTitle("confirmation");
 
   modal.addLabelComponents(
-    new LabelBuilder().setLabel("type 'yes' to confirm").setTextInputComponent(
-      new TextInputBuilder()
-        .setCustomId("confirmation")
-        .setPlaceholder(
-          action == "buy"
-            ? `this will cost $${cost.toLocaleString()}`
-            : `the average worth of this item is $${cost.toLocaleString()}`,
-        )
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true)
-        .setMaxLength(3),
-    ),
+    new LabelBuilder()
+      .setLabel(`confirm your ${action == "buy" ? "purchase" : "sale"}`)
+      .setDescription(
+        action == "buy"
+          ? `this will cost $${cost.toLocaleString()}`
+          : `the average worth of this item is $${cost.toLocaleString()}`,
+      )
+      .setCheckboxGroupComponent(
+        new CheckboxGroupBuilder()
+          .setCustomId("confirmation")
+          .setOptions([{ label: "confirm", value: "confirm" }])
+          .setMinValues(0)
+          .setRequired(false)
+          .setMaxValues(1),
+      ),
   );
 
   await interaction.showModal(modal);
@@ -1213,7 +1215,7 @@ export async function showMarketConfirmationModal(
 
   if (!res.isModalSubmit()) return;
 
-  if (res.fields.getTextInputValue("confirmation") != "yes") {
+  if (!res.fields.getCheckboxGroup("confirmation").includes("confirm")) {
     res.reply({
       embeds: [new CustomEmbed().setDescription("✅ cancelled purchase")],
       flags: MessageFlags.Ephemeral,


### PR DESCRIPTION
old
<img width="700" height="462" alt="image" src="https://github.com/user-attachments/assets/5dfdccda-e77d-465f-ac40-ff20b58d7221" />

new
<img width="611" height="410" alt="image" src="https://github.com/user-attachments/assets/ce207769-bbd0-4976-b45d-710f66a70384" />

says `confirm your sale` when selling an item