### PR TITLE
feat(lottery): lottery every 8 hours and superdraws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - lottery updates
   - lottery every 8 hours (3/day)
-	- superdraw on friday night, 2-10% of all tickets bought through the week get added to a draw
+  - superdraw on friday night, 2-10% of all tickets bought through the week get added to a draw
 
 # may 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# june 2026
+
+- lottery updates
+  - lottery every 8 hours (3/day)
+	- superdraw on friday night, 2-10% of all tickets bought through the week get added to a draw
+
 # may 2026
 
 - add help chat bot

--- a/data/achievements.json
+++ b/data/achievements.json
@@ -833,7 +833,7 @@
     "emoji": "🍀",
     "target": 75,
     "description": "win the lottery 75 times",
-    "prize": ["legendary_scratch_card:2", "nypsi_crate:2", "omega_crate:1"]
+    "prize": ["legendary_scratch_card:2", "nypsi_crate:2"]
   },
   "lucky_v": {
     "id": "lucky_v",
@@ -841,7 +841,7 @@
     "emoji": "🍀",
     "target": 150,
     "description": "win the lottery 150 times",
-    "prize": ["nypsi_crate:3", "platinum_credit:4", "omega_crate:2", "rain:1"]
+    "prize": ["nypsi_crate:3", "silver_credit:3", "rain:1"]
   },
   "wordle_i": {
     "id": "wordle_i",

--- a/data/items.json
+++ b/data/items.json
@@ -3743,6 +3743,18 @@
     "in_crates": true,
     "aliases": ["lotto", "lottery"]
   },
+  "superdraw_lottery_ticket": {
+    "id": "superdraw_lottery_ticket",
+    "name": "superdraw lottery ticket",
+    "article": "a",
+    "plural": "lottery tickets",
+    "emoji": "🎫",
+    "longDesc": "maybe you'll get lucky on friday night!",
+    "rarity": 0,
+    "role": "lottery ticket",
+    "sell": 10000,
+    "in_crates": true
+  },
   "orange": {
     "id": "orange",
     "name": "orange",

--- a/data/items.json
+++ b/data/items.json
@@ -3741,7 +3741,8 @@
     "buy": 30000,
     "sell": 10000,
     "in_crates": true,
-    "aliases": ["lotto", "lottery"]
+    "aliases": ["lotto", "lottery"],
+    "default_count": 3
   },
   "superdraw_lottery_ticket": {
     "id": "superdraw_lottery_ticket",
@@ -3753,7 +3754,8 @@
     "rarity": 0,
     "role": "lottery ticket",
     "sell": 10000,
-    "in_crates": true
+    "in_crates": true,
+    "default_count": 2
   },
   "orange": {
     "id": "orange",

--- a/prisma/migrations/20260626171405_add_lottery_stuff/migration.sql
+++ b/prisma/migrations/20260626171405_add_lottery_stuff/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "LotteryType" AS ENUM ('standard', 'superdraw');
+
+-- CreateEnum
+CREATE TYPE "LotteryAutoBuy" AS ENUM ('daily', 'lottery');
+
+-- AlterTable
+ALTER TABLE "Economy" RENAME COLUMN "dailyLottery" TO "autobuyLotteryTicketsAmount";
+
+-- AlterTable
+ALTER TABLE "Economy" ADD COLUMN "autobuyLotteryTicketsTime" "LotteryAutoBuy";
+
+-- CreateTable
+CREATE TABLE "Lottery" (
+    "id" SERIAL NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "type" "LotteryType" NOT NULL DEFAULT 'standard',
+    "winnerId" TEXT,
+    "winnerTickets" BIGINT NOT NULL,
+    "totalTickets" BIGINT NOT NULL,
+
+    CONSTRAINT "Lottery_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Lottery" ADD CONSTRAINT "Lottery_winnerId_fkey" FOREIGN KEY ("winnerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260626171405_add_lottery_stuff/migration.sql
+++ b/prisma/migrations/20260626171405_add_lottery_stuff/migration.sql
@@ -10,6 +10,10 @@ ALTER TABLE "Economy" RENAME COLUMN "dailyLottery" TO "autobuyLotteryTicketsAmou
 -- AlterTable
 ALTER TABLE "Economy" ADD COLUMN "autobuyLotteryTicketsTime" "LotteryAutoBuy";
 
+-- Backfill existing autobuy users to the previous behavior (daily)
+UPDATE "Economy"
+SET "autobuyLotteryTicketsTime" = 'daily'
+WHERE "autobuyLotteryTicketsAmount" IS NOT NULL AND "autobuyLotteryTicketsAmount" > 0;
 -- CreateTable
 CREATE TABLE "Lottery" (
     "id" SERIAL NOT NULL,

--- a/prisma/migrations/20260626180833_add_lottery_table/migration.sql
+++ b/prisma/migrations/20260626180833_add_lottery_table/migration.sql
@@ -1,3 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `dailyLottery` on the `Economy` table. All the data in the column will be lost.
+
+*/
 -- CreateEnum
 CREATE TYPE "LotteryType" AS ENUM ('standard', 'superdraw');
 
@@ -5,10 +11,9 @@ CREATE TYPE "LotteryType" AS ENUM ('standard', 'superdraw');
 CREATE TYPE "LotteryAutoBuy" AS ENUM ('daily', 'lottery');
 
 -- AlterTable
-ALTER TABLE "Economy" RENAME COLUMN "dailyLottery" TO "autobuyLotteryTicketsAmount";
-
--- AlterTable
-ALTER TABLE "Economy" ADD COLUMN "autobuyLotteryTicketsTime" "LotteryAutoBuy";
+ALTER TABLE "Economy" DROP COLUMN "dailyLottery",
+ADD COLUMN     "autobuyLotteryTicketsAmount" INTEGER,
+ADD COLUMN     "autobuyLotteryTicketsTime" "LotteryAutoBuy";
 
 -- Backfill existing autobuy users to the previous behavior (daily)
 UPDATE "Economy"
@@ -22,6 +27,7 @@ CREATE TABLE "Lottery" (
     "winnerId" TEXT,
     "winnerTickets" BIGINT NOT NULL,
     "totalTickets" BIGINT NOT NULL,
+    "totalWin" BIGINT,
 
     CONSTRAINT "Lottery_pkey" PRIMARY KEY ("id")
 );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,16 @@ enum LevelDmSetting {
   OnlyReward
 }
 
+enum LotteryType {
+  standard
+  superdraw
+}
+
+enum LotteryAutoBuy {
+  daily // every day
+  lottery // every lottery
+}
+
 enum OrderType {
   buy
   sell
@@ -156,6 +166,7 @@ model User {
   RoleplayStat             RoleplayStat[]
   RoleplayStatTarget       RoleplayStat[]             @relation(name: "target")
   SudokuGame               SudokuGame[]
+  lotteryWins              Lottery[]
 }
 
 model ProfileView {
@@ -316,7 +327,8 @@ model Economy {
   sellallFilter String[]
   offersBlock   String[]
 
-  dailyLottery Int?
+  autobuyLotteryTicketsAmount Int?
+  autobuyLotteryTicketsTime   LotteryAutoBuy?
 
   preferredPickaxe        ToolPreferenceSelection @default(highest)
   preferredRod            ToolPreferenceSelection @default(highest)
@@ -732,6 +744,19 @@ model Marriage {
   marriageStart DateTime @default(now())
 
   @@id([userId, partnerId])
+}
+
+model Lottery {
+  id   Int      @id @default(autoincrement())
+  date DateTime @default(now())
+
+  type LotteryType @default(standard)
+
+  winnerId String?
+  winner   User?   @relation(fields: [winnerId], references: [id], onDelete: SetNull)
+
+  winnerTickets BigInt
+  totalTickets  BigInt
 }
 
 // guild specific tables

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -757,6 +757,7 @@ model Lottery {
 
   winnerTickets BigInt
   totalTickets  BigInt
+  totalWin      BigInt?
 }
 
 // guild specific tables

--- a/src/commands/buy.ts
+++ b/src/commands/buy.ts
@@ -88,7 +88,7 @@ async function run(
     return send({ embeds: [new ErrorEmbed("you cannot buy this item")] });
   }
 
-  if (selected.id === "lottery_ticket") {
+  if (selected.role === "lottery ticket") {
     const limit = dayjs().set("hour", 23).set("minute", 59).set("second", 0).set("millisecond", 0);
 
     if (dayjs().isAfter(limit) || (await redis.exists("nypsi:lottery"))) {
@@ -163,7 +163,7 @@ async function run(
         .catch(() => msg.edit({ components: [row] }));
     }
 
-    if (selected.id === "lottery_ticket") {
+    if (selected.role === "lottery ticket") {
       const limit = dayjs()
         .set("hour", 23)
         .set("minute", 59)

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -162,6 +162,7 @@ async function run(
                 },
               },
             },
+            lotteryWins: true,
             Premium: {
               include: {
                 PremiumCommand: true,

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -133,7 +133,6 @@ async function run(
     const tickets = inventory.count("lottery_ticket");
     const superdrawTickets = inventory.count("superdraw_lottery_ticket");
     const embed = new CustomEmbed(message.member);
-
     const pool = await getApproximatePrizePool();
     const autoBuy = await getLotteryAutoBuySettings(message.member);
     const autoBuyText =
@@ -142,18 +141,21 @@ async function run(
             autoBuy.time === "lottery" ? "every lottery" : "daily"
           }`
         : "";
-
     embed.setHeader("lottery", message.author.avatarURL());
+
+    const now = dayjs();
+    const hoursUntilNext = 8 - (now.hour() % 8);
+    const nextDrawTime = now.add(hoursUntilNext, "hour").startOf("hour");
+
+    const nextDrawIsSuperdraw = nextDrawTime.day() === 6;
+    const nextDrawText = `<t:${nextDrawTime.unix()}:R>${nextDrawIsSuperdraw ? " ([superdraw](https://nypsi.xyz/wiki/economy/lottery?ref=bot-lottery#superdraw))" : ""}`;
+
     embed.setDescription(
-      `nypsi lottery is a daily draw which happens in the [official nypsi server](${Constants.NYPSI_SERVER_INVITE_LINK})\nnext draw <t:${dayjs()
-        .add(1, "day")
-        .startOf("day")
-        .unix()}:R>\n\n` +
+      `nypsi lottery draws happen every 8 hours in the [official nypsi server](${Constants.NYPSI_SERVER_INVITE_LINK})\nnext draw ${nextDrawText}\n\n` +
         `current prize pool is $**${formatNumberPretty(pool.min)}** - $**${formatNumberPretty(pool.max)}**\n\n` +
         `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\n` +
         `you have **${tickets.toLocaleString()}** tickets and **${superdrawTickets.toLocaleString()}** [superdraw tickets](https://nypsi.xyz/wiki/economy/lottery?ref=bot-lottery#superdraw)${autoBuyText}`,
     );
-
     return send({ embeds: [embed] });
   };
 

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -20,6 +20,7 @@ import { getInventory } from "../utils/functions/economy/inventory";
 import {
   getApproximatePrizePool,
   getLotteryAutoBuySettings,
+  getLotteryStats,
   setLotteryAutoBuySettings,
 } from "../utils/functions/economy/lottery";
 import {
@@ -39,7 +40,8 @@ cmd.slashData
   )
   .addSubcommand((tickets) =>
     tickets.setName("view").setDescription("view the current lottery status"),
-  );
+  )
+  .addSubcommand((stats) => stats.setName("stats").setDescription("view your lottery stats"));
 
 type LotteryAutoBuyMode = "daily" | "lottery";
 
@@ -155,6 +157,32 @@ async function run(
     return send({ embeds: [embed] });
   };
 
+  const stats = async () => {
+    const data = await getLotteryStats(message.member);
+    const embed = new CustomEmbed(message.member).setHeader(
+      "lottery stats",
+      message.author.avatarURL(),
+    );
+
+    if (data.wins === 0) {
+      embed.setDescription("you have not won any lotteries yet");
+      return send({ embeds: [embed] });
+    }
+
+    const recent = data.mostRecentWin;
+    const biggest = data.biggestWin;
+
+    embed.setDescription(
+      `wins: **${data.wins.toLocaleString()}**\n\n` +
+        `most recent win: **${recent.type}** <t:${Math.floor(recent.date.getTime() / 1000)}:R>\n` +
+        `you won with **${recent.winnerTickets.toLocaleString()}** tickets (**${recent.totalTickets.toLocaleString()}** total bought)\n\n` +
+        `biggest win: **${biggest.type}**\n` +
+        `you won with **${biggest.winnerTickets.toLocaleString()}** tickets (**${biggest.totalTickets.toLocaleString()}** total bought)`,
+    );
+
+    return send({ embeds: [embed] });
+  };
+
   if (args.length == 0) {
     return help();
   } else if (args[0].toLowerCase() == "buy" || args[0].toLowerCase() == "b") {
@@ -168,6 +196,8 @@ async function run(
     });
   } else if (args[0].toLowerCase() == "view") {
     return help();
+  } else if (args[0].toLowerCase() == "stats") {
+    return stats();
   } else if (args[0].toLowerCase() === "autobuy") {
     const settings = await getLotteryAutoBuySettings(message.member);
 

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -6,8 +6,8 @@ import Constants from "../utils/Constants";
 import { getInventory } from "../utils/functions/economy/inventory";
 import {
   getApproximatePrizePool,
-  getDailyLottoTickets,
-  setDailyLotteryTickets,
+  getLotteryAutoBuySettings,
+  setLotteryAutoBuySettings,
 } from "../utils/functions/economy/lottery";
 import {
   createUser,
@@ -48,7 +48,13 @@ async function run(
     const embed = new CustomEmbed(message.member);
 
     const pool = await getApproximatePrizePool();
-    const autoBuy = await getDailyLottoTickets(message.member);
+    const autoBuy = await getLotteryAutoBuySettings(message.member);
+    const autoBuyText =
+      typeof autoBuy.amount === "number"
+        ? `, auto buying ${autoBuy.amount} tickets ${
+            autoBuy.time === "lottery" ? "every lottery" : "daily"
+          }`
+        : "";
 
     embed.setHeader("lottery", message.author.avatarURL());
     embed.setDescription(
@@ -57,7 +63,7 @@ async function run(
         .startOf("day")
         .unix()}:R>\n\n` +
         `current prize pool is $**${formatNumberPretty(pool.min)}** - $**${formatNumberPretty(pool.max)}**\n\n` +
-        `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\nyou have **${tickets.toLocaleString()}** tickets${typeof autoBuy === "number" ? `, auto buying ${autoBuy} tickets daily` : ""}`,
+        `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\nyou have **${tickets.toLocaleString()}** tickets${autoBuyText}`,
     );
 
     return send({ embeds: [embed] });
@@ -91,7 +97,7 @@ async function run(
       return send({ embeds: [new ErrorEmbed("invalid number")] });
     }
 
-    await setDailyLotteryTickets(message.member, amount);
+    await setLotteryAutoBuySettings(message.member, amount, "daily");
 
     return send({
       embeds: [

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -1,5 +1,18 @@
 import dayjs = require("dayjs");
-import { CommandInteraction } from "discord.js";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  CommandInteraction,
+  Interaction,
+  LabelBuilder,
+  MessageActionRowComponentBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  TextInputBuilder,
+  TextInputStyle,
+} from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage, SendMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import Constants from "../utils/Constants";
@@ -22,19 +35,89 @@ const cmd = new Command("lottery", "enter the daily lottery draw", "money").setA
 cmd.slashEnabled = true;
 cmd.slashData
   .addSubcommand((autobuy) =>
-    autobuy
-      .setName("autobuy")
-      .setDescription("auto buy lottery tickets at a discount")
-      .addStringOption((option) =>
-        option
-          .setName("amount")
-          .setDescription("amount of lottery tickets to auto buy daily")
-          .setRequired(true),
-      ),
+    autobuy.setName("autobuy").setDescription("manage lottery autobuy settings"),
   )
   .addSubcommand((tickets) =>
     tickets.setName("view").setDescription("view the current lottery status"),
   );
+
+type LotteryAutoBuyMode = "daily" | "lottery";
+
+function createAutoBuyEmbed(
+  member: NypsiMessage["member"],
+  amount: number | null,
+  mode: LotteryAutoBuyMode | null,
+) {
+  const modeText = mode === "lottery" ? "every lottery" : mode === "daily" ? "daily" : "none";
+  const amountText = typeof amount === "number" ? amount.toLocaleString() : "disabled";
+  const costText =
+    typeof amount === "number"
+      ? `$${Math.ceil(getItems()["lottery_ticket"].buy * amount * 0.95).toLocaleString()}`
+      : "n/a";
+
+  return new CustomEmbed(member)
+    .setHeader("lottery autobuy")
+    .setDescription(
+      `configure your lottery autobuy settings\n\n` +
+        `mode: **${modeText}**\n` +
+        `amount: **${amountText}**\n` +
+        `cost per run: **${costText}** (5% discount)\n\n` +
+        `use the buttons below to change mode, set amount, or disable autobuy`,
+    );
+}
+
+function createAutoBuyRow(
+  mode: LotteryAutoBuyMode | null,
+  disabled = false,
+): ActionRowBuilder<MessageActionRowComponentBuilder> {
+  return new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("autobuy-mode-daily")
+      .setLabel("daily")
+      .setStyle(mode === "daily" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(disabled),
+    new ButtonBuilder()
+      .setCustomId("autobuy-mode-lottery")
+      .setLabel("every lottery")
+      .setStyle(mode === "lottery" ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(disabled),
+    new ButtonBuilder()
+      .setCustomId("autobuy-set-amount")
+      .setLabel("set amount")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled),
+    new ButtonBuilder()
+      .setCustomId("autobuy-disable")
+      .setLabel("disable")
+      .setStyle(ButtonStyle.Danger)
+      .setDisabled(disabled),
+  );
+}
+
+async function getAmountFromModal(interaction: ButtonInteraction) {
+  const id = `lottery-autobuy-amount-${Math.floor(Math.random() * 1_000_000)}`;
+  const modal = new ModalBuilder().setCustomId(id).setTitle("set lottery autobuy amount");
+
+  modal.addLabelComponents(
+    new LabelBuilder()
+      .setLabel("amount of tickets")
+      .setTextInputComponent(
+        new TextInputBuilder()
+          .setCustomId("amount")
+          .setPlaceholder("enter a number between 0 and 100000")
+          .setStyle(TextInputStyle.Short)
+          .setRequired(true)
+          .setMaxLength(6),
+      ),
+  );
+
+  await interaction.showModal(modal);
+
+  const filter = (i: ModalSubmitInteraction) =>
+    i.user.id === interaction.user.id && i.customId === id;
+
+  return await interaction.awaitModalSubmit({ filter, time: 60_000 }).catch(() => {});
+}
 
 async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
@@ -83,30 +166,85 @@ async function run(
   } else if (args[0].toLowerCase() == "view") {
     return help();
   } else if (args[0].toLowerCase() === "autobuy") {
-    if (args.length === 1) {
-      return send({ embeds: [new ErrorEmbed("$lotto autobuy <amount>")] });
-    }
+    const settings = await getLotteryAutoBuySettings(message.member);
 
-    const amount = parseInt(args[1]);
+    let amount: number | null = settings.amount;
+    let mode: LotteryAutoBuyMode | null = settings.time as LotteryAutoBuyMode | null;
 
-    if (isNaN(amount) || amount < 0) {
-      return send({ embeds: [new ErrorEmbed("invalid number")] });
-    }
-
-    if (amount > 100000) {
-      return send({ embeds: [new ErrorEmbed("invalid number")] });
-    }
-
-    await setLotteryAutoBuySettings(message.member, amount, "daily");
-
-    return send({
-      embeds: [
-        new CustomEmbed(
-          message.member,
-          `you will now auto buy **${amount}** lottery tickets daily ($${(amount * getItems()["lottery_ticket"].buy).toLocaleString()}) at a **5%** discount`,
-        ),
-      ],
+    const msg = await send({
+      embeds: [createAutoBuyEmbed(message.member, amount, mode)],
+      components: [createAutoBuyRow(mode)],
     });
+
+    const filter = (i: Interaction) => i.user.id === message.author.id;
+
+    const listen = async (): Promise<void> => {
+      const collected = await msg
+        .awaitMessageComponent({ filter, time: 120_000 })
+        .catch(async () => {
+          await msg.edit({ components: [createAutoBuyRow(mode, true)] }).catch(() => {});
+        });
+
+      if (!collected || !collected.isButton()) return;
+
+      if (collected.customId === "autobuy-mode-daily") {
+        mode = "daily";
+        await setLotteryAutoBuySettings(message.member, amount, mode);
+        await collected.update({
+          embeds: [createAutoBuyEmbed(message.member, amount, mode)],
+          components: [createAutoBuyRow(mode)],
+        });
+      } else if (collected.customId === "autobuy-mode-lottery") {
+        mode = "lottery";
+        await setLotteryAutoBuySettings(message.member, amount, mode);
+        await collected.update({
+          embeds: [createAutoBuyEmbed(message.member, amount, mode)],
+          components: [createAutoBuyRow(mode)],
+        });
+      } else if (collected.customId === "autobuy-set-amount") {
+        const modalSubmit = await getAmountFromModal(collected);
+
+        if (!modalSubmit) return;
+
+        const input = modalSubmit.fields.getTextInputValue("amount").trim();
+        const nextAmount = parseInt(input, 10);
+
+        if (isNaN(nextAmount) || nextAmount < 0 || nextAmount > 100000) {
+          await modalSubmit.reply({ embeds: [new ErrorEmbed("invalid number")], ephemeral: true });
+          return listen();
+        }
+
+        amount = nextAmount;
+
+        if (amount === 0) {
+          amount = null;
+        }
+
+        if (!mode) {
+          mode = "daily";
+        }
+
+        await setLotteryAutoBuySettings(message.member, amount, mode);
+
+        await modalSubmit.deferUpdate();
+        await msg.edit({
+          embeds: [createAutoBuyEmbed(message.member, amount, mode)],
+          components: [createAutoBuyRow(mode)],
+        });
+      } else if (collected.customId === "autobuy-disable") {
+        amount = null;
+        mode = null;
+        await setLotteryAutoBuySettings(message.member, null, null);
+        await collected.update({
+          embeds: [createAutoBuyEmbed(message.member, amount, mode)],
+          components: [createAutoBuyRow(mode)],
+        });
+      }
+
+      return listen();
+    };
+
+    return listen();
   } else {
     return help();
   }

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -33,7 +33,7 @@ cmd.slashData
       ),
   )
   .addSubcommand((tickets) =>
-    tickets.setName("tickets").setDescription("view your current tickets"),
+    tickets.setName("view").setDescription("view the current lottery status"),
   );
 
 async function run(
@@ -80,7 +80,7 @@ async function run(
         ),
       ],
     });
-  } else if (args[0].toLowerCase() == "tickets") {
+  } else if (args[0].toLowerCase() == "view") {
     return help();
   } else if (args[0].toLowerCase() === "autobuy") {
     if (args.length === 1) {

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -156,7 +156,16 @@ async function run(
         `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\n` +
         `you have **${tickets.toLocaleString()}** tickets and **${superdrawTickets.toLocaleString()}** [superdraw tickets](https://nypsi.xyz/wiki/economy/lottery?ref=bot-lottery#superdraw)${autoBuyText}`,
     );
-    return send({ embeds: [embed] });
+
+    const components = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+      new ButtonBuilder()
+        .setStyle(ButtonStyle.Link)
+        .setLabel("history")
+        .setEmoji("💎")
+        .setURL("https://nypsi.xyz/lotteries?ref=bot-lottery"),
+    );
+
+    return send({ embeds: [embed], components: [components] });
   };
 
   const stats = async () => {

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -127,7 +127,9 @@ async function run(
   if (!(await userExists(message.member))) await createUser(message.member);
 
   const help = async () => {
-    const tickets = (await getInventory(message.member)).count("lottery_ticket");
+    const inventory = await getInventory(message.member);
+    const tickets = inventory.count("lottery_ticket");
+    const superdrawTickets = inventory.count("superdraw_lottery_ticket");
     const embed = new CustomEmbed(message.member);
 
     const pool = await getApproximatePrizePool();
@@ -146,7 +148,8 @@ async function run(
         .startOf("day")
         .unix()}:R>\n\n` +
         `current prize pool is $**${formatNumberPretty(pool.min)}** - $**${formatNumberPretty(pool.max)}**\n\n` +
-        `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\nyou have **${tickets.toLocaleString()}** tickets${autoBuyText}`,
+        `you can buy lottery tickets with ${(await getPrefix(message.guild))[0]}**buy lotto**\n` +
+        `you have **${tickets.toLocaleString()}** tickets and **${superdrawTickets.toLocaleString()}** [superdraw tickets](https://nypsi.xyz/wiki/economy/lottery?ref=bot-lottery#superdraw)${autoBuyText}`,
     );
 
     return send({ embeds: [embed] });

--- a/src/commands/top.ts
+++ b/src/commands/top.ts
@@ -405,7 +405,7 @@ async function run(
       return send({ embeds: [new ErrorEmbed(`couldn't find ${searchTag}`)] });
     }
 
-    if (item.id === "lottery_ticket")
+    if (item.role === "lottery ticket")
       return send({ embeds: [new ErrorEmbed("leaderboards for this item are unavailable")] });
 
     if (item.id == "gold_star") return showMuseumLeaderboard(message, send, args);
@@ -681,7 +681,7 @@ async function run(
 
     if (!selected) return send({ embeds: [new ErrorEmbed("invalid option")] });
 
-    if (selected.id === "lottery_ticket")
+    if (selected.id === "lottery ticket")
       return send({ embeds: [new ErrorEmbed("leaderboards for this item are unavailable")] });
 
     if (selected.id == "gold_star")

--- a/src/commands/top.ts
+++ b/src/commands/top.ts
@@ -681,7 +681,7 @@ async function run(
 
     if (!selected) return send({ embeds: [new ErrorEmbed("invalid option")] });
 
-    if (selected.id === "lottery ticket")
+    if (selected.role === "lottery ticket")
       return send({ embeds: [new ErrorEmbed("leaderboards for this item are unavailable")] });
 
     if (selected.id == "gold_star")

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -14,7 +14,7 @@ import { addStat } from "../../utils/functions/economy/stats";
 import { getItems } from "../../utils/functions/economy/utils";
 import { percentChance } from "../../utils/functions/random";
 import { pluralize } from "../../utils/functions/string";
-import { getTax } from "../../utils/functions/tax";
+import { addToNypsiBank, getTax } from "../../utils/functions/tax";
 import { addNotificationToQueue, getDmSettings } from "../../utils/functions/users/notifications";
 import { getLastKnownAvatar, getLastKnownUsername } from "../../utils/functions/users/username";
 import { logger } from "../../utils/logger";
@@ -69,10 +69,6 @@ export default {
       await hook.send({ embeds: [embed] });
       hook.destroy();
     } else {
-      const taxedAmount = Math.floor(totalPool * (await getTax())) * 1.5;
-
-      const totalPrize = Math.floor(totalPool - taxedAmount);
-
       const before = performance.now();
       const winner = await findWinner(tickets);
       const after = performance.now();
@@ -84,6 +80,12 @@ export default {
         await redis.del("nypsi:lottery");
         return;
       }
+
+      const winnerShare = winner.amount / total;
+      const progressiveTaxMultiplier = getProgressiveTaxMultiplier(winnerShare);
+      const taxedAmount = Math.floor(totalPool * (await getTax()) * progressiveTaxMultiplier);
+      const nypsiBankShare = Math.floor(taxedAmount / 2);
+      const totalPrize = Math.floor(totalPool - taxedAmount);
 
       const winnerUsername = await getLastKnownUsername(winner.userId, false);
       const winnerAvatar = await getLastKnownAvatar(winner.userId);
@@ -106,6 +108,7 @@ export default {
           total,
           isSuperDraw ? "superdraw" : "standard",
         ),
+        addToNypsiBank(nypsiBankShare),
         addBalance(winner.userId, totalPrize),
         addProgress(winner.userId, "lucky", 1),
         addStat(winner.userId, "earned-lottery", totalPrize),
@@ -210,6 +213,17 @@ async function findWinner(tickets: { userId: string; amount: bigint }[]) {
 
   // this should never happen
   return { userId: Constants.BOT_USER_ID, tickets: -1 };
+}
+
+function getProgressiveTaxMultiplier(winnerShare: number): number {
+  const minMultiplier = 0.5;
+  const maxMultiplier = 1.5;
+  const clampedShare = Math.min(Math.max(winnerShare, 0), 1);
+
+  // Smoothstep keeps transitions gradual while preserving low->high scaling by winner share.
+  const t = clampedShare * clampedShare * (3 - 2 * clampedShare);
+
+  return minMultiplier + (maxMultiplier - minMultiplier) * t;
 }
 
 async function deleteAllTickets(userIds: string[], isSuperDraw: boolean) {

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -24,6 +24,11 @@ export default {
   name: "lottery",
   cron: "0 */8 * * *",
   async run(log) {
+    if (await redis.exists(Constants.redis.nypsi.INFINITE_MAX_BET)) {
+      log("skipping lottery during season interim");
+      return;
+    }
+
     const now = new Date();
     const isSuperDraw = now.getDay() === 6 && now.getHours() === 0;
     const drawTicketItems = isSuperDraw

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -200,7 +200,9 @@ export default {
   },
 } satisfies Job;
 
-async function findWinner(tickets: { userId: string; amount: bigint }[]) {
+async function findWinner(
+  tickets: { userId: string; amount: bigint }[],
+): Promise<{ userId: string; amount: number }> {
   const ticketCount = tickets.map((i) => i.amount).reduce((a, b) => a + b);
 
   let r = BigInt(randomInt(Number(ticketCount) + 1));
@@ -213,7 +215,7 @@ async function findWinner(tickets: { userId: string; amount: bigint }[]) {
   }
 
   // this should never happen
-  return { userId: Constants.BOT_USER_ID, tickets: -1 };
+  return { userId: Constants.BOT_USER_ID, amount: -1 };
 }
 
 function getProgressiveTaxMultiplier(winnerShare: number): number {

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -23,23 +23,45 @@ export default {
   name: "lottery",
   cron: "0 */8 * * *",
   async run(log) {
+    const now = new Date();
+    const isSuperDraw = now.getDay() === 6 && now.getHours() === 0;
+    const lotteryType = isSuperDraw ? "superdraw" : "standard";
+    const drawTicketItems = isSuperDraw
+      ? ["lottery_ticket", "superdraw_lottery_ticket"]
+      : ["lottery_ticket"];
+
     await redis.set("nypsi:lottery", "boobies", "EX", 3600);
     const hook = new WebhookClient({ url: process.env.LOTTERY_HOOK });
 
-    const tickets = await prisma.inventory.findMany({
-      where: { item: "lottery_ticket" },
-      select: { userId: true, amount: true },
+    const ticketRows = await prisma.inventory.findMany({
+      where: { item: { in: drawTicketItems } },
+      select: { userId: true, item: true, amount: true },
     });
-    const total = Number(tickets.map((i) => i.amount).reduce((a, b) => a + b, 0n));
 
-    if (total < 100) {
+    const ticketMap = new Map<string, bigint>();
+
+    for (const ticket of ticketRows) {
+      ticketMap.set(ticket.userId, (ticketMap.get(ticket.userId) ?? 0n) + ticket.amount);
+    }
+
+    const tickets = Array.from(ticketMap.entries()).map(([userId, amount]) => ({ userId, amount }));
+    const total = Number(tickets.map((i) => i.amount).reduce((a, b) => a + b, 0n));
+    const lotteryTicketValue = getItems()["lottery_ticket"].buy;
+    const totalPool = total * lotteryTicketValue;
+
+    const uniqueUsers = ticketRows.reduce(
+      (acc, curr) => acc.add(curr.userId),
+      new Set<string>(),
+    ).size;
+
+    if (total < 500 || uniqueUsers < 10) {
       log(`${total} tickets were bought ): maybe tomorrow you'll have something to live for`);
 
       const embed = new CustomEmbed();
 
       embed.setTitle("lottery cancelled");
       embed.setDescription(
-        `the lottery has been cancelled as only **${total}** tickets were bought ):\n\nthese tickets will remain and the lottery will happen tomorrow`,
+        `**ROLLOVER**\n\nnot enough participating tickets, existing tickets will rollover to the next draw`,
       );
       embed.setColor(flavors.latte.colors.base.hex as ColorResolvable);
       embed.disableFooter();
@@ -47,10 +69,9 @@ export default {
       await hook.send({ embeds: [embed] });
       hook.destroy();
     } else {
-      const taxedAmount =
-        Math.floor(total * getItems()["lottery_ticket"].buy * (await getTax())) * 1.5;
+      const taxedAmount = Math.floor(totalPool * (await getTax())) * 1.5;
 
-      const totalPrize = Math.floor(total * getItems()["lottery_ticket"].buy - taxedAmount);
+      const totalPrize = Math.floor(totalPool - taxedAmount);
 
       const before = performance.now();
       const winner = await findWinner(tickets);
@@ -67,12 +88,15 @@ export default {
       const winnerUsername = await getLastKnownUsername(winner.userId, false);
       const winnerAvatar = await getLastKnownAvatar(winner.userId);
 
-      deleteAllTickets(tickets);
+      await deleteAllTickets(
+        tickets.map((i) => i.userId),
+        isSuperDraw,
+      );
 
       log(`winner: ${winner.userId} (${winnerUsername})`);
 
       await Promise.all([
-        createLotteryEntry(winner.userId, winner.amount, total),
+        createLotteryEntry(winner.userId, winner.amount, total, lotteryType),
         addBalance(winner.userId, totalPrize),
         addProgress(winner.userId, "lucky", 1),
         addStat(winner.userId, "earned-lottery", totalPrize),
@@ -80,7 +104,7 @@ export default {
 
       const embed = new CustomEmbed();
 
-      embed.setHeader("lottery winner", winnerAvatar);
+      embed.setHeader(`${lotteryType} winner`, winnerAvatar);
       embed.setDescription(
         `**${winnerUsername.replaceAll("_", "\\_")}** has won the lottery with ${winner.amount.toLocaleString()} tickets!!\n\n` +
           `they have won $**${totalPrize.toLocaleString()}**`,
@@ -93,7 +117,7 @@ export default {
       hook.destroy();
 
       if ((await getDmSettings(winner.userId)).lottery) {
-        embed.setTitle("you have won the lottery!");
+        embed.setTitle(`you have won the ${lotteryType}!`);
         embed.setDescription(
           `you have won a total of $**${totalPrize.toLocaleString()}**\n\nyou had ${winner.amount.toLocaleString()} tickets`,
         );
@@ -127,7 +151,7 @@ export default {
 
     await redis.del("nypsi:lottery");
 
-    const isDailyAutoBuyRun = new Date().getHours() === 0;
+    const isDailyAutoBuyRun = now.getHours() === 0;
     const autoBuys = await getLotteryAutoBuyUsers(isDailyAutoBuyRun);
 
     for (const user of autoBuys) {
@@ -179,11 +203,15 @@ async function findWinner(tickets: { userId: string; amount: bigint }[]) {
   return { userId: Constants.BOT_USER_ID, tickets: -1 };
 }
 
-async function deleteAllTickets(tickets: { userId: string }[]) {
+async function deleteAllTickets(userIds: string[], isSuperDraw: boolean) {
   const promises: (() => Promise<void>)[] = [];
 
-  for (const ticket of tickets) {
-    promises.push(() => setInventoryItem(ticket.userId, "lottery_ticket", 0));
+  for (const userId of userIds) {
+    promises.push(() => setInventoryItem(userId, "lottery_ticket", 0));
+
+    if (isSuperDraw) {
+      promises.push(() => setInventoryItem(userId, "superdraw_lottery_ticket", 0));
+    }
   }
 
   await pAll(promises, { concurrency: 5 });

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -9,7 +9,7 @@ import Constants from "../../utils/Constants";
 import { addProgress } from "../../utils/functions/economy/achievements";
 import { addBalance, getBalance, removeBalance } from "../../utils/functions/economy/balance";
 import { addInventoryItem, setInventoryItem } from "../../utils/functions/economy/inventory";
-import { createLotteryEntry } from "../../utils/functions/economy/lottery";
+import { createLotteryEntry, getLotteryAutoBuyUsers } from "../../utils/functions/economy/lottery";
 import { addStat } from "../../utils/functions/economy/stats";
 import { getItems } from "../../utils/functions/economy/utils";
 import { percentChance } from "../../utils/functions/random";
@@ -128,28 +128,7 @@ export default {
     await redis.del("nypsi:lottery");
 
     const isDailyAutoBuyRun = new Date().getHours() === 0;
-
-    const autoBuys = await prisma.economy.findMany({
-      where: {
-        autobuyLotteryTicketsAmount: { gt: 0 },
-        autobuyLotteryTicketsTime: {
-          in: isDailyAutoBuyRun ? ["lottery", "daily"] : ["lottery"],
-        },
-      },
-      select: {
-        userId: true,
-        autobuyLotteryTicketsAmount: true,
-        user: {
-          select: {
-            DMSettings: {
-              select: {
-                other: true,
-              },
-            },
-          },
-        },
-      },
-    });
+    const autoBuys = await getLotteryAutoBuyUsers(isDailyAutoBuyRun);
 
     for (const user of autoBuys) {
       const balance = await getBalance(user.userId);

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -9,6 +9,7 @@ import Constants from "../../utils/Constants";
 import { addProgress } from "../../utils/functions/economy/achievements";
 import { addBalance, getBalance, removeBalance } from "../../utils/functions/economy/balance";
 import { addInventoryItem, setInventoryItem } from "../../utils/functions/economy/inventory";
+import { createLotteryEntry } from "../../utils/functions/economy/lottery";
 import { addStat } from "../../utils/functions/economy/stats";
 import { getItems } from "../../utils/functions/economy/utils";
 import { percentChance } from "../../utils/functions/random";
@@ -20,7 +21,7 @@ import pAll = require("p-all");
 
 export default {
   name: "lottery",
-  cron: "0 0 * * *",
+  cron: "0 */8 * * *",
   async run(log) {
     await redis.set("nypsi:lottery", "boobies", "EX", 3600);
     const hook = new WebhookClient({ url: process.env.LOTTERY_HOOK });
@@ -71,6 +72,7 @@ export default {
       log(`winner: ${winner.userId} (${winnerUsername})`);
 
       await Promise.all([
+        createLotteryEntry(winner.userId, winner.amount, total),
         addBalance(winner.userId, totalPrize),
         addProgress(winner.userId, "lucky", 1),
         addStat(winner.userId, "earned-lottery", totalPrize),
@@ -125,13 +127,18 @@ export default {
 
     await redis.del("nypsi:lottery");
 
+    const isDailyAutoBuyRun = new Date().getHours() === 0;
+
     const autoBuys = await prisma.economy.findMany({
       where: {
-        dailyLottery: { gt: 0 },
+        autobuyLotteryTicketsAmount: { gt: 0 },
+        autobuyLotteryTicketsTime: {
+          in: isDailyAutoBuyRun ? ["lottery", "daily"] : ["lottery"],
+        },
       },
       select: {
         userId: true,
-        dailyLottery: true,
+        autobuyLotteryTicketsAmount: true,
         user: {
           select: {
             DMSettings: {
@@ -147,13 +154,19 @@ export default {
     for (const user of autoBuys) {
       const balance = await getBalance(user.userId);
 
-      const cost = Math.ceil(getItems()["lottery_ticket"].buy * user.dailyLottery * 0.95);
+      const amount = user.autobuyLotteryTicketsAmount;
+
+      if (!amount || amount <= 0) {
+        continue;
+      }
+
+      const cost = Math.ceil(getItems()["lottery_ticket"].buy * amount * 0.95);
 
       if (balance >= cost) {
-        log(`auto buying ${user.dailyLottery} lottery tickets for ${user.userId}`);
+        log(`auto buying ${amount} lottery tickets for ${user.userId}`);
         await removeBalance(user.userId, cost);
         addStat(user.userId, "spent-shop", cost);
-        await addInventoryItem(user.userId, "lottery_ticket", user.dailyLottery);
+        await addInventoryItem(user.userId, "lottery_ticket", amount);
 
         if (user.user.DMSettings.other) {
           await addNotificationToQueue({
@@ -161,7 +174,7 @@ export default {
             payload: {
               embed: new CustomEmbed(
                 user.userId,
-                `you have auto bought **${user.dailyLottery}** lottery tickets`,
+                `you have auto bought **${amount}** lottery tickets`,
               ),
             },
           });

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -106,6 +106,7 @@ export default {
           winner.userId,
           winner.amount,
           total,
+          totalPrize,
           isSuperDraw ? "superdraw" : "standard",
         ),
         addToNypsiBank(nypsiBankShare),

--- a/src/scheduled/jobs/lottery.ts
+++ b/src/scheduled/jobs/lottery.ts
@@ -13,6 +13,7 @@ import { createLotteryEntry, getLotteryAutoBuyUsers } from "../../utils/function
 import { addStat } from "../../utils/functions/economy/stats";
 import { getItems } from "../../utils/functions/economy/utils";
 import { percentChance } from "../../utils/functions/random";
+import { pluralize } from "../../utils/functions/string";
 import { getTax } from "../../utils/functions/tax";
 import { addNotificationToQueue, getDmSettings } from "../../utils/functions/users/notifications";
 import { getLastKnownAvatar, getLastKnownUsername } from "../../utils/functions/users/username";
@@ -25,7 +26,6 @@ export default {
   async run(log) {
     const now = new Date();
     const isSuperDraw = now.getDay() === 6 && now.getHours() === 0;
-    const lotteryType = isSuperDraw ? "superdraw" : "standard";
     const drawTicketItems = isSuperDraw
       ? ["lottery_ticket", "superdraw_lottery_ticket"]
       : ["lottery_ticket"];
@@ -88,6 +88,10 @@ export default {
       const winnerUsername = await getLastKnownUsername(winner.userId, false);
       const winnerAvatar = await getLastKnownAvatar(winner.userId);
 
+      if (!isSuperDraw) {
+        await addSuperdrawRolloverTickets(tickets, log);
+      }
+
       await deleteAllTickets(
         tickets.map((i) => i.userId),
         isSuperDraw,
@@ -96,7 +100,12 @@ export default {
       log(`winner: ${winner.userId} (${winnerUsername})`);
 
       await Promise.all([
-        createLotteryEntry(winner.userId, winner.amount, total, lotteryType),
+        createLotteryEntry(
+          winner.userId,
+          winner.amount,
+          total,
+          isSuperDraw ? "superdraw" : "standard",
+        ),
         addBalance(winner.userId, totalPrize),
         addProgress(winner.userId, "lucky", 1),
         addStat(winner.userId, "earned-lottery", totalPrize),
@@ -104,9 +113,9 @@ export default {
 
       const embed = new CustomEmbed();
 
-      embed.setHeader(`${lotteryType} winner`, winnerAvatar);
+      embed.setHeader(`lottery winner`, winnerAvatar);
       embed.setDescription(
-        `**${winnerUsername.replaceAll("_", "\\_")}** has won the lottery with ${winner.amount.toLocaleString()} tickets!!\n\n` +
+        `**${winnerUsername.replaceAll("_", "\\_")}** has won the ${isSuperDraw ? "**SUPERDRAW**" : ""} lottery with ${winner.amount.toLocaleString()} tickets!!\n\n` +
           `they have won $**${totalPrize.toLocaleString()}**`,
       );
       embed.setFooter({ text: `a total of ${total.toLocaleString()} tickets were bought` });
@@ -117,9 +126,9 @@ export default {
       hook.destroy();
 
       if ((await getDmSettings(winner.userId)).lottery) {
-        embed.setTitle(`you have won the ${lotteryType}!`);
+        embed.setTitle(`you have won the lottery!`);
         embed.setDescription(
-          `you have won a total of $**${totalPrize.toLocaleString()}**\n\nyou had ${winner.amount.toLocaleString()} tickets`,
+          `you have won a total of $**${totalPrize.toLocaleString()}**\n\nyou had ${winner.amount.toLocaleString()} ${pluralize("ticket", winner.amount)}`,
         );
         embed.setColor(flavors.latte.colors.base.hex as ColorResolvable);
 
@@ -215,4 +224,57 @@ async function deleteAllTickets(userIds: string[], isSuperDraw: boolean) {
   }
 
   await pAll(promises, { concurrency: 5 });
+}
+
+function getSuperdrawChance(ticketAmount: number): number {
+  const maxChance = 0.1;
+  const minChance = 0.025;
+  const maxTicketsForMinChance = 1000;
+
+  const clamped = Math.min(Math.max(ticketAmount, 1), maxTicketsForMinChance);
+  const t = (clamped - 1) / (maxTicketsForMinChance - 1);
+  const progress = 1 - Math.pow(1 - t, 5);
+
+  return maxChance - (maxChance - minChance) * progress;
+}
+
+function rollSuperdrawTickets(ticketAmount: number): number {
+  const chance = getSuperdrawChance(ticketAmount);
+  let granted = 0;
+
+  for (let i = 0; i < ticketAmount; i++) {
+    if (percentChance(chance)) {
+      granted++;
+    }
+  }
+
+  return granted;
+}
+
+async function addSuperdrawRolloverTickets(
+  tickets: { userId: string; amount: bigint }[],
+  log: (message: string) => void,
+) {
+  const tasks: (() => Promise<void>)[] = [];
+
+  for (const ticket of tickets) {
+    const amount = Number(ticket.amount);
+
+    if (!amount || amount <= 0) {
+      continue;
+    }
+
+    const granted = rollSuperdrawTickets(amount);
+
+    if (granted <= 0) {
+      continue;
+    }
+
+    tasks.push(async () => {
+      await addInventoryItem(ticket.userId, "superdraw_lottery_ticket", granted);
+      log(`rolled ${granted} superdraw tickets for ${ticket.userId} from ${amount} tickets`);
+    });
+  }
+
+  await pAll(tasks, { concurrency: 5 });
 }

--- a/src/scheduled/jobs/seed-leaderboards.ts
+++ b/src/scheduled/jobs/seed-leaderboards.ts
@@ -22,7 +22,9 @@ export default {
   cron: "0 4 * * *",
   run: async () => {
     const start = Date.now();
-    const itemIds = Object.keys(getItems()).filter((i) => i !== "lottery_ticket");
+    const itemIds = Object.keys(getItems()).filter(
+      (i) => i !== "lottery_ticket" && i !== "superdraw_lottery_ticket",
+    );
 
     await topBalance("global", undefined, undefined, 100);
     await sleep(1000);

--- a/src/scheduled/jobs/topsnapshot.ts
+++ b/src/scheduled/jobs/topsnapshot.ts
@@ -84,7 +84,10 @@ async function doItems() {
     .toDate();
 
   for (const i of query) {
-    if (i.item === "lottery_ticket") i._sum.amount = BigInt(0);
+    if (i.item === "lottery_ticket" || i.item === "superdraw_lottery_ticket") {
+      i._sum.amount = BigInt(0);
+    }
+
     await prisma.graphMetrics.create({
       data: {
         category: `item-count-${i.item}`,

--- a/src/utils/functions/economy/achievements.ts
+++ b/src/utils/functions/economy/achievements.ts
@@ -187,6 +187,7 @@ async function completeAchievement(userId: string, achievementId: string) {
   if (earnedCrates > 0) {
     rewardsDesc.push(`+ \`${earnedCrates}x\` 🎁 69420 crate`);
     await addInventoryItem(userId, "69420_crate", earnedCrates);
+    await addInventoryItem(userId, "lottery_ticket", earnedCrates);
   }
 
   if (rewardsDesc.length > 0) {

--- a/src/utils/functions/economy/inventory.ts
+++ b/src/utils/functions/economy/inventory.ts
@@ -402,7 +402,9 @@ export async function setInventoryItem(member: MemberResolvable, itemId: string,
 }
 
 export async function getTotalAmountOfItem(itemId: string) {
-  if (itemId === "lottery_ticket") return 0;
+  if (itemId === "lottery_ticket" || itemId === "superdraw_lottery_ticket") {
+    return 0;
+  }
 
   const query = await prisma.inventory.aggregate({
     where: {

--- a/src/utils/functions/economy/item_info.ts
+++ b/src/utils/functions/economy/item_info.ts
@@ -368,7 +368,7 @@ function getGeneralMessage(
       `**worth** ${value ? `$${Math.floor(value).toLocaleString()}` : "[unvalued](https://nypsi.xyz/wiki/economy/items/worth?ref=bot-item#unvalued)"}`,
     );
 
-    if (total && selected.id !== "lottery_ticket") {
+    if (total && selected.role !== "lottery ticket") {
       description.push(`\n**in world** ${total.toLocaleString()}`);
     }
 

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -43,3 +43,17 @@ export async function setDailyLotteryTickets(member: MemberResolvable, amount: n
     },
   });
 }
+
+export async function createLotteryEntry(
+  winnerId: string,
+  winnerTickets: number,
+  totalTickets: number,
+) {
+  await prisma.lottery.create({
+    data: {
+      winnerId,
+      winnerTickets: BigInt(winnerTickets),
+      totalTickets: BigInt(totalTickets),
+    },
+  });
+}

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -41,8 +41,8 @@ export async function getLotteryAutoBuySettings(member: MemberResolvable) {
 
 export async function setLotteryAutoBuySettings(
   member: MemberResolvable,
-  amount: number,
-  mode: LotteryAutoBuyMode,
+  amount: number | null,
+  mode: LotteryAutoBuyMode | null,
 ) {
   await prisma.economy.update({
     where: {
@@ -50,7 +50,7 @@ export async function setLotteryAutoBuySettings(
     },
     data: {
       autobuyLotteryTicketsAmount: amount,
-      autobuyLotteryTicketsTime: amount > 0 ? mode : null,
+      autobuyLotteryTicketsTime: mode,
     },
   });
 }

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -83,9 +83,11 @@ export async function createLotteryEntry(
   winnerId: string,
   winnerTickets: number,
   totalTickets: number,
+  type: "standard" | "superdraw" = "standard",
 ) {
   await prisma.lottery.create({
     data: {
+      type,
       winnerId,
       winnerTickets: BigInt(winnerTickets),
       totalTickets: BigInt(totalTickets),

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -83,6 +83,7 @@ export async function createLotteryEntry(
   winnerId: string,
   winnerTickets: number,
   totalTickets: number,
+  totalWinnings: number,
   type: "standard" | "superdraw" = "standard",
 ) {
   await prisma.lottery.create({
@@ -91,6 +92,7 @@ export async function createLotteryEntry(
       winnerId,
       winnerTickets: BigInt(winnerTickets),
       totalTickets: BigInt(totalTickets),
+      totalWin: BigInt(totalWinnings),
     },
   });
 }

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -94,3 +94,38 @@ export async function createLotteryEntry(
     },
   });
 }
+
+export async function getLotteryStats(member: MemberResolvable) {
+  const userId = getUserId(member);
+
+  const wins = await prisma.lottery.findMany({
+    where: {
+      winnerId: userId,
+    },
+    orderBy: {
+      date: "desc",
+    },
+    select: {
+      date: true,
+      type: true,
+      winnerTickets: true,
+      totalTickets: true,
+    },
+  });
+
+  const mostRecentWin = wins[0] ?? null;
+
+  let biggestWin = wins[0] ?? null;
+
+  for (const win of wins) {
+    if (!biggestWin || win.winnerTickets > biggestWin.winnerTickets) {
+      biggestWin = win;
+    }
+  }
+
+  return {
+    wins: wins.length,
+    mostRecentWin,
+    biggestWin,
+  };
+}

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -2,6 +2,8 @@ import prisma from "../../../init/database";
 import { getUserId, MemberResolvable } from "../member";
 import { getItems } from "./utils";
 
+type LotteryAutoBuyMode = "daily" | "lottery";
+
 export async function getApproximatePrizePool() {
   const tickets = await prisma.inventory.aggregate({
     where: {
@@ -20,26 +22,59 @@ export async function getApproximatePrizePool() {
   };
 }
 
-export async function getDailyLottoTickets(member: MemberResolvable) {
+export async function getLotteryAutoBuySettings(member: MemberResolvable) {
   const query = await prisma.economy.findUnique({
     where: {
       userId: getUserId(member),
     },
     select: {
-      dailyLottery: true,
+      autobuyLotteryTicketsAmount: true,
+      autobuyLotteryTicketsTime: true,
     },
   });
 
-  return query.dailyLottery;
+  return {
+    amount: query.autobuyLotteryTicketsAmount,
+    time: query.autobuyLotteryTicketsTime,
+  };
 }
 
-export async function setDailyLotteryTickets(member: MemberResolvable, amount: number) {
+export async function setLotteryAutoBuySettings(
+  member: MemberResolvable,
+  amount: number,
+  mode: LotteryAutoBuyMode,
+) {
   await prisma.economy.update({
     where: {
       userId: getUserId(member),
     },
     data: {
-      dailyLottery: amount,
+      autobuyLotteryTicketsAmount: amount,
+      autobuyLotteryTicketsTime: amount > 0 ? mode : null,
+    },
+  });
+}
+
+export async function getLotteryAutoBuyUsers(isDailyAutoBuyRun: boolean) {
+  return prisma.economy.findMany({
+    where: {
+      autobuyLotteryTicketsAmount: { gt: 0 },
+      autobuyLotteryTicketsTime: {
+        in: isDailyAutoBuyRun ? ["lottery", "daily"] : ["lottery"],
+      },
+    },
+    select: {
+      userId: true,
+      autobuyLotteryTicketsAmount: true,
+      user: {
+        select: {
+          DMSettings: {
+            select: {
+              other: true,
+            },
+          },
+        },
+      },
     },
   });
 }

--- a/src/utils/functions/economy/tasks.ts
+++ b/src/utils/functions/economy/tasks.ts
@@ -320,6 +320,7 @@ export async function addTaskProgress(member: MemberResolvable, taskId: string, 
 
       addInlineNotification({ embed, memberId: task.user_id });
       addProgress(task.user_id, "taskmaster", 1);
+      addInventoryItem(task.user_id, "lottery_ticket", 1);
 
       if (task.type === "daily") addTaskProgress(task.user_id, "all_dailies");
     } else {

--- a/src/utils/functions/economy/utils.ts
+++ b/src/utils/functions/economy/utils.ts
@@ -781,6 +781,7 @@ export async function doDaily(
       promises.push(() => addBalance(marriage.partnerId, marriageMoney));
       promises.push(() => addXp(marriage.partnerId, marriageXp));
       promises.push(() => addInventoryItem(marriage.partnerId, "daily_scratch_card", 1));
+      promises.push(() => addInventoryItem(marriage.partnerId, "lottery_ticket", 1));
 
       const embed = new CustomEmbed(marriage.partnerId);
 
@@ -812,27 +813,19 @@ export async function doDaily(
   ];
 
   for (const [itemId, amount] of totalRewards) {
-    promises.push(async () => {
-      await addInventoryItem(member, itemId, amount);
-    });
+    promises.push(() => addInventoryItem(member, itemId, amount));
 
     rewards.push(
       `+ **${amount.toLocaleString()}** ${items[itemId].emoji} ${pluralize(items[itemId], amount)}`,
     );
   }
 
-  promises.push(async () => {
-    await addBalance(member, totalMoney);
-  });
-
-  promises.push(async () => {
-    await addInventoryItem(member, "daily_scratch_card", totalCards);
-  });
+  promises.push(() => addBalance(member, totalMoney));
+  promises.push(() => addInventoryItem(member, "daily_scratch_card", totalCards));
+  promises.push(() => addInventoryItem(member, "lottery_ticket", totalCards));
 
   if (!rerun) {
-    promises.push(async () => {
-      await updateLastDaily(member, updateLast, amount);
-    });
+    promises.push(() => updateLastDaily(member, updateLast, amount));
   }
 
   await pAll(promises, { concurrency: 3 });


### PR DESCRIPTION
- **feat(schema): add lottery table and more refined auto buy columns**
- **feat(lottery): run every 8 hours and insert into lottery table and properly handle tickets**
- **refactor(lottery): improve handling of lottery auto buy settings**
- **fix(lottery): change /lottery tickets to /lottery view**
- **feat(lottery): update cmd ui for new autobuy settings**
- **feat(lottery): add superdraw ticket**
- **feat(lottery): add superdraw**
- **feat(lottery): give superdraw tickets**
- **fix(lottery): reduce winnings for easier achievement**
- **feat(lottery): add progressive tax based on majority of tickets**
- **feat(db): add migration**
- **feat(lottery): add stats**
- **fix(data): include lottery wins with data package**
- **feat(lottery): more frequent lottery ticket rewards**
