### PR TITLE
fix museum interaction reply

### DIFF
--- a/src/commands/museum.ts
+++ b/src/commands/museum.ts
@@ -756,7 +756,7 @@ async function run(
       await addToMuseum(message.member, item.id, amount);
       await removeInventoryItem(message.member, item.id, amount);
 
-      interaction.update({
+      await interaction.update({
         embeds: [
           new CustomEmbed(
             message.member,


### PR DESCRIPTION
## What changed

Await the museum donation confirmation interaction update before sending inline notification follow-ups.

## Why

The update acknowledgement and follow-up were previously started concurrently, so Discord could receive the follow-up before the button interaction was acknowledged. This produced recurring InteractionNotReplied errors.

## Impact

Museum donation confirmations can now safely send inline notifications without intermittently failing.

## Validation

- git diff --check
- make check could not run because dependencies were absent and npm registry DNS resolution failed in the sandbox.