### PR TITLE
fix(preferences): default privacy mode to disabled

### DIFF
--- a/data/preferences.json
+++ b/data/preferences.json
@@ -140,7 +140,7 @@
       "id": "leaderboards",
       "name": "privacy",
       "description": "enabling privacy hides your username from global leaderboards and stops your profile being visible on the nypsi website",
-      "default": true
+      "default": false
     },
     "tips": {
       "id": "tips",

--- a/src/commands/viewgame.ts
+++ b/src/commands/viewgame.ts
@@ -13,7 +13,7 @@ import { Command, NypsiCommandInteraction, NypsiMessage, SendMessage } from "../
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { fetchGame } from "../utils/functions/economy/stats";
 import PageManager from "../utils/functions/page";
-import { getPreferences } from "../utils/functions/users/preferences";
+import { getPrivacyEnabled, getPrivacyEnabledUserIds } from "../utils/functions/users/preferences";
 import { getLastKnownAvatar, getLastKnownUsername } from "../utils/functions/users/username";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import dayjs = require("dayjs");
@@ -91,13 +91,9 @@ async function run(
 
     if (query.length === 0) return send({ embeds: [new ErrorEmbed("no results found")] });
 
-    const preferences = new Map(
-      await Promise.all(
-        [...new Set(query.map((game) => game.userId))].map(
-          async (userId) => [userId, await getPreferences(userId)] as const,
-        ),
-      ),
-    );
+    const privateUserIds = await getPrivacyEnabledUserIds([
+      ...new Set(query.map((game) => game.userId)),
+    ]);
 
     const embed = new CustomEmbed(message.member).setFooter({
       text: `${query.length.toLocaleString()} ${query.length >= 1000 ? "(max) " : ""}results found`,
@@ -110,9 +106,7 @@ async function run(
             36,
           )}?ref=bot-game) \`(${game.id})\`\n` +
           `**user** \`${
-            !preferences.get(game.userId).leaderboards
-              ? game.economy.user.lastKnownUsername
-              : "[hidden]"
+            !privateUserIds.has(game.userId) ? game.economy.user.lastKnownUsername : "[hidden]"
           }\`\n` +
           `**game** \`${game.game}\`\n` +
           `**time** <t:${Math.floor(game.date.getTime() / 1000)}>\n` +
@@ -163,7 +157,7 @@ async function run(
         query.map((game) => {
           return {
             id: game.id.toString(36),
-            user: !preferences.get(game.userId).leaderboards
+            user: !privateUserIds.has(game.userId)
               ? game.economy.user.lastKnownUsername
               : "[hidden]",
             game: game.game,
@@ -203,9 +197,9 @@ async function run(
     if (!game)
       return send({ embeds: [new ErrorEmbed(`couldn't find a game with id \`${args[0]}\``)] });
 
-    const username = !(await getPreferences(game.userId))?.leaderboards
-      ? await getLastKnownUsername(game.userId, false).catch(() => {})
-      : "[hidden]";
+    const username = (await getPrivacyEnabled(game.userId))
+      ? "[hidden]"
+      : await getLastKnownUsername(game.userId, false).catch(() => {});
 
     const embed = new CustomEmbed(game.userId).setHeader(
       username ? `${username}'s ${game.game} game` : `id: ${game.id.toString(36)}`,

--- a/src/utils/functions/users/preferences.ts
+++ b/src/utils/functions/users/preferences.ts
@@ -86,6 +86,29 @@ export async function getPreferences(member: MemberResolvable): Promise<Preferen
   return preferences;
 }
 
+export async function getPrivacyEnabled(member: MemberResolvable): Promise<boolean> {
+  const userId = getUserId(member);
+  const preference = await prisma.preferences.findUnique({
+    where: { userId_key: { userId, key: "leaderboards" } },
+    select: { value: true },
+  });
+
+  return preference?.value === true;
+}
+
+export async function getPrivacyEnabledUserIds(userIds: string[]): Promise<Set<string>> {
+  const preferences = await prisma.preferences.findMany({
+    where: {
+      userId: { in: userIds },
+      key: "leaderboards",
+      value: { equals: true },
+    },
+    select: { userId: true },
+  });
+
+  return new Set(preferences.map((preference) => preference.userId));
+}
+
 export async function updatePreference<K extends PreferenceKey>(
   member: MemberResolvable,
   key: K,


### PR DESCRIPTION
## Summary

Sets privacy mode to disabled by default, so usernames remain visible on public leaderboards unless a user explicitly enables privacy.

Optimizes /viewgame privacy checks to query only sparse leaderboards: true overrides instead of hydrating every matched user's full preferences.

## Root cause

The sparse preferences refactor retained a true default for the privacy setting, causing users without an explicit override to be treated as private.

## Validation

- pnpm lint
- pnpm format:check
- pnpm vitest run test/data/preferences.test.ts